### PR TITLE
[schematic] - Removed tsconfig.federation.json from builder and added it to the init schematic

### DIFF
--- a/packages/angular/src/builders/build/builder.ts
+++ b/packages/angular/src/builders/build/builder.ts
@@ -86,10 +86,7 @@ const createInternalAngularBuilder =
     // modifications don't reach here. Add NF externals to externalDependencies so
     // Angular routes them to optimizeDeps.exclude, preventing Vite from trying to
     // pre-bundle packages that include native .node binaries.
-    options.externalDependencies = [
-      ...(options.externalDependencies ?? []),
-      ...externals,
-    ];
+    options.externalDependencies = [...(options.externalDependencies ?? []), ...externals];
 
     // Todo: share cache with Angular builder: https://github.com/angular/angular-cli/pull/32527
     // options.codeBundleCache = nfOptions.federationCache.bundlerCache;
@@ -176,6 +173,8 @@ export async function* runBuilder(
     ngBuilderOptions.outputPath = nfBuilderOptions.outputPath;
   }
 
+  const federationTsConfig = nfBuilderOptions.tsConfig || ngBuilderOptions.tsConfig;
+
   const adapter = createAngularBuildAdapter(ngBuilderOptions, context);
 
   setBuildAdapter(adapter);
@@ -218,7 +217,7 @@ export async function* runBuilder(
   const entryPoints: string[] | undefined =
     nfBuilderOptions.entryPoints && nfBuilderOptions.entryPoints.length > 0
       ? nfBuilderOptions.entryPoints
-      : [path.join(path.dirname(ngBuilderOptions.tsConfig), 'src/main.ts')];
+      : [path.join(path.dirname(federationTsConfig), 'src/main.ts')];
 
   const cachePath = getDefaultCachePath(context.workspaceRoot);
 
@@ -227,8 +226,8 @@ export async function* runBuilder(
       projectName: nfBuilderOptions.projectName,
       workspaceRoot: context.workspaceRoot,
       outputPath: browserOutputPath,
-      federationConfig: inferConfigPath(ngBuilderOptions.tsConfig),
-      tsConfig: ngBuilderOptions.tsConfig,
+      federationConfig: inferConfigPath(federationTsConfig),
+      tsConfig: federationTsConfig,
       verbose: ngBuilderOptions.verbose,
       watch: ngBuilderOptions.watch,
       dev: !!nfBuilderOptions.dev,
@@ -324,7 +323,7 @@ export async function* runBuilder(
     nfBuilderOptions.dev || watch ? createNfWatcher() : undefined;
 
   if (nfWatcher) {
-    nfWatcher.add(path.dirname(path.resolve(context.workspaceRoot, ngBuilderOptions.tsConfig)));
+    nfWatcher.add(path.dirname(path.resolve(context.workspaceRoot, federationTsConfig)));
   }
 
   if (existsSync(normalized.options.outputPath)) {

--- a/packages/angular/src/builders/build/builder.ts
+++ b/packages/angular/src/builders/build/builder.ts
@@ -173,7 +173,10 @@ export async function* runBuilder(
     ngBuilderOptions.outputPath = nfBuilderOptions.outputPath;
   }
 
-  const federationTsConfig = nfBuilderOptions.tsConfig || ngBuilderOptions.tsConfig;
+  const federationTsConfig =
+    !!nfBuilderOptions.tsConfig && nfBuilderOptions.tsConfig.length > 0
+      ? nfBuilderOptions.tsConfig
+      : ngBuilderOptions.tsConfig;
 
   const adapter = createAngularBuildAdapter(ngBuilderOptions, context);
 

--- a/packages/angular/src/builders/build/schema.d.ts
+++ b/packages/angular/src/builders/build/schema.d.ts
@@ -16,6 +16,7 @@ export interface NfBuilderSchema extends JsonObject {
   outputPath?: string;
   projectName?: string;
   ssr: boolean;
+  tsConfig: string;
   devServer?: boolean;
   entryPoints?: string[];
   cacheExternalArtifacts?: boolean;

--- a/packages/angular/src/builders/build/schema.d.ts
+++ b/packages/angular/src/builders/build/schema.d.ts
@@ -16,7 +16,7 @@ export interface NfBuilderSchema extends JsonObject {
   outputPath?: string;
   projectName?: string;
   ssr: boolean;
-  tsConfig: string;
+  tsConfig?: string;
   devServer?: boolean;
   entryPoints?: string[];
   cacheExternalArtifacts?: boolean;

--- a/packages/angular/src/builders/build/schema.json
+++ b/packages/angular/src/builders/build/schema.json
@@ -60,6 +60,10 @@
       "type": "boolean",
       "description": "can be used to disable the dev server when dev=true"
     },
+    "tsConfig": {
+      "type": "string", 
+      "description": "A specific tsconfig file for the nf remotes and exposed modules."
+    },
     "cacheExternalArtifacts": {
       "type": "boolean",
       "default": true,

--- a/packages/angular/src/schematics/init/schematic.ts
+++ b/packages/angular/src/schematics/init/schematic.ts
@@ -15,6 +15,7 @@ import { updateWorkspaceConfig } from './steps/update-workspace-config.js';
 import { addDependencies } from './steps/add-dependencies.js';
 import { makeMainAsync } from './steps/make-main-async.js';
 import { makeServerAsync } from './steps/make-server-async.js';
+import { generateTsConfig } from './steps/generate-tsconfig.js';
 
 export { updatePackageJson, patchAngularBuild } from './steps/update-package-json.js';
 export { getWorkspaceFileName } from './steps/normalize-options.js';
@@ -52,6 +53,8 @@ export default function config(options: NfSchematicSchema): Rule {
     const cand2 = path.join(projectSourceRoot, 'app', 'app.ts').replace(/\\/g, '/');
 
     const appComponent = tree.exists(cand1) ? cand1 : tree.exists(cand2) ? cand2 : 'update-this.ts';
+
+    generateTsConfig(tree, projectRoot, main);
 
     const generateRule = !exists
       ? generateFederationConfig(

--- a/packages/angular/src/schematics/init/steps/generate-tsconfig.ts
+++ b/packages/angular/src/schematics/init/steps/generate-tsconfig.ts
@@ -1,0 +1,30 @@
+import type { Tree } from '@angular-devkit/schematics';
+import * as path from 'path';
+
+export function generateTsConfig(
+  tree: Tree,
+  projectRoot: string,
+  main: string
+): void {
+  const tsconfigPath = path.join(projectRoot, 'tsconfig.federation.json').replace(/\\/g, '/');
+
+  if (tree.exists(tsconfigPath)) {
+    return;
+  }
+
+  const relToRoot = path.relative(projectRoot, '.').replace(/\\/g, '/') || '.';
+  const mainRelative = path.relative(projectRoot, main).replace(/\\/g, '/');
+
+  const tsconfig = {
+    extends: `${relToRoot}/tsconfig.json`,
+    compilerOptions: {
+      outDir: `${relToRoot}/out-tsc/app`,
+      types: [],
+    },
+    include: ['src/**/*.ts'],
+    exclude: ['src/**/*.spec.ts'],
+    files: [mainRelative],
+  };
+
+  tree.create(tsconfigPath, JSON.stringify(tsconfig, null, 2) + '\n');
+}

--- a/packages/angular/src/schematics/init/steps/update-workspace-config.ts
+++ b/packages/angular/src/schematics/init/steps/update-workspace-config.ts
@@ -9,9 +9,10 @@ export function updateWorkspaceConfig(
   workspaceFileName: string,
   ssr: boolean
 ) {
-  const { projectConfig, projectName, port, main, projectSourceRoot } = options;
+  const { projectConfig, projectName, projectRoot, port, main, projectSourceRoot } = options;
 
   const entryPoints = main ? [main] : [path.join(projectSourceRoot, 'main.ts')];
+  const tsConfig = path.join(projectRoot, 'tsconfig.federation.json').replace(/\\/g, '/');
 
   if (!projectConfig?.architect?.build || !projectConfig?.architect?.serve) {
     throw new Error(`The project doesn't have a build or serve target in angular.json!`);
@@ -51,6 +52,7 @@ export function updateWorkspaceConfig(
     builder: '@angular-architects/native-federation-v4:build',
     options: {
       projectName,
+      tsConfig,
       cacheExternalArtifacts: true,
       entryPoints,
     },
@@ -95,6 +97,7 @@ export function updateWorkspaceConfig(
     builder: '@angular-architects/native-federation-v4:build',
     options: {
       projectName,
+      tsConfig,
       target: `${projectName}:serve-original:development`,
       rebuildDelay: 500,
       cacheExternalArtifacts: true,

--- a/packages/angular/src/utils/angular-bundler.ts
+++ b/packages/angular/src/utils/angular-bundler.ts
@@ -19,7 +19,7 @@ import {
 
 import { createAwaitableCompilerPlugin } from './create-awaitable-compiler-plugin.js';
 import type { NormalizedContextOptions } from './normalize-context-options.js';
-import { createFederationTsConfig } from './create-federation-tsconfig.js';
+import { updateFederationTsConfig } from './create-federation-tsconfig.js';
 
 export async function createAngularEsbuildContext(options: NormalizedContextOptions): Promise<{
   ctx: esbuild.BuildContext;
@@ -81,12 +81,11 @@ export async function createAngularEsbuildContext(options: NormalizedContextOpti
     }
   }
 
-  tsConfigPath = createFederationTsConfig(
-    workspaceRoot,
-    tsConfigPath,
-    entryPoints,
-    optimizedMappings
-  );
+  if (optimizedMappings) {
+    updateFederationTsConfig(workspaceRoot, tsConfigPath, entryPoints);
+  }
+
+  tsConfigPath = path.join(workspaceRoot, tsConfigPath);
 
   const pluginOptions: CompilerPluginOptions = {
     sourcemap: !!sourcemapOptions.scripts && (sourcemapOptions.hidden ? 'external' : true),

--- a/packages/angular/src/utils/create-federation-tsconfig.ts
+++ b/packages/angular/src/utils/create-federation-tsconfig.ts
@@ -5,49 +5,43 @@ import JSON5 from 'json5';
 import { isDeepStrictEqual } from 'util';
 
 /**
- * Creates a tsconfig.federation.json that includes the federation entry points.
+ * Updates the federation tsconfig to include optimized mapping entry points.
+ * Only modifies the file when there are non-local entry points to add.
  */
-export function createFederationTsConfig(
+export function updateFederationTsConfig(
   workspaceRoot: string,
   tsConfigPath: string,
-  entryPoints: EntryPoint[],
-  optimizedMappings?: boolean
-): string {
+  entryPoints: EntryPoint[]
+): void {
   const fullTsConfigPath = path.join(workspaceRoot, tsConfigPath);
   const tsconfigDir = path.dirname(fullTsConfigPath);
+
+  const filtered = entryPoints
+    .filter(ep => !ep.fileName.startsWith('.'))
+    .map(ep => path.relative(tsconfigDir, ep.fileName).replace(/\\\\/g, '/'));
+
+  if (filtered.length === 0) {
+    return;
+  }
 
   const tsconfigAsString = fs.readFileSync(fullTsConfigPath, 'utf-8');
   const tsconfig = JSON5.parse(tsconfigAsString);
 
-  tsconfig.files = entryPoints
-    .filter(ep => ep.fileName.startsWith('.'))
-    .map(ep => path.relative(tsconfigDir, ep.fileName).replace(/\\\\/g, '/'));
+  if (!tsconfig.include) {
+    tsconfig.include = [];
+  }
 
-  if (optimizedMappings) {
-    const filtered = entryPoints
-      .filter(ep => !ep.fileName.startsWith('.'))
-      .map(ep => path.relative(tsconfigDir, ep.fileName).replace(/\\\\/g, '/'));
-
-    if (!tsconfig.include) {
-      tsconfig.include = [];
-    }
-
-    for (const ep of filtered) {
-      if (!tsconfig.include.includes(ep)) {
-        tsconfig.include.push(ep);
-      }
+  for (const ep of filtered) {
+    if (!tsconfig.include.includes(ep)) {
+      tsconfig.include.push(ep);
     }
   }
 
   const content = JSON5.stringify(tsconfig, null, 2);
 
-  const tsconfigFedPath = path.join(tsconfigDir, 'tsconfig.federation.json');
-
-  if (!doesFileExistAndJsonEqual(tsconfigFedPath, content)) {
-    fs.writeFileSync(tsconfigFedPath, JSON.stringify(tsconfig, null, 2));
+  if (!doesFileExistAndJsonEqual(fullTsConfigPath, content)) {
+    fs.writeFileSync(fullTsConfigPath, JSON.stringify(tsconfig, null, 2));
   }
-
-  return tsconfigFedPath;
 }
 
 function doesFileExistAndJsonEqual(filePath: string, content: string): boolean {

--- a/packages/angular/tsconfig.tsbuildinfo
+++ b/packages/angular/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"fileNames":[],"fileInfos":[],"root":[],"options":{"composite":true,"declarationMap":true,"importHelpers":true,"module":199,"noEmitOnError":true,"noFallthroughCasesInSwitch":true,"noImplicitOverride":true,"noImplicitReturns":true,"noUncheckedIndexedAccess":true,"noUnusedLocals":true,"noUnusedParameters":true,"skipLibCheck":true,"strict":true,"target":99},"version":"5.9.3"}

--- a/packages/angular/tsconfig.tsbuildinfo
+++ b/packages/angular/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"fileNames":[],"fileInfos":[],"root":[],"options":{"composite":true,"declarationMap":true,"importHelpers":true,"module":199,"noEmitOnError":true,"noFallthroughCasesInSwitch":true,"noImplicitOverride":true,"noImplicitReturns":true,"noUncheckedIndexedAccess":true,"noUnusedLocals":true,"noUnusedParameters":true,"skipLibCheck":true,"strict":true,"target":99},"version":"5.9.3"}


### PR DESCRIPTION
This pull request introduces support for specifying a dedicated TypeScript configuration file (`tsconfig.federation.json`) for Native Federation builds in Angular projects. It adds schema and schematic support for this new option, ensures the config file is generated and referenced appropriately, and refines how entry points are handled in the federation tsconfig. The changes improve flexibility for projects with custom or multiple entry points and streamline the federation build process.

**Support for dedicated federation TypeScript config:**

* Added a new `tsConfig` option to the builder schema (`schema.json`) to allow specifying a custom TypeScript config for federation builds.
* Updated the schematic to generate a `tsconfig.federation.json` file during project initialization, ensuring federation builds have an appropriate config. [[1]](diffhunk://#diff-d22bc9cdaf84ee4c5ad8abe65a3952565db7628a5fbf2b10d00184b1d4e87e76R18) [[2]](diffhunk://#diff-d22bc9cdaf84ee4c5ad8abe65a3952565db7628a5fbf2b10d00184b1d4e87e76R57-R58) [[3]](diffhunk://#diff-2a7ffba82c99818ae327639873beb2bf5dd1a72c0db56a6dcc09cd0c4e2088b5R1-R30)
* Modified the workspace config update logic to reference the new federation tsconfig in build and serve targets. [[1]](diffhunk://#diff-e5ff5a79df4011f6c8334fac7ddac65b8cf26fb2d14da0195421481470a5a730L12-R15) [[2]](diffhunk://#diff-e5ff5a79df4011f6c8334fac7ddac65b8cf26fb2d14da0195421481470a5a730R55) [[3]](diffhunk://#diff-e5ff5a79df4011f6c8334fac7ddac65b8cf26fb2d14da0195421481470a5a730R100)

**Builder and entry point handling:**

* Updated the Angular builder to consistently use the federation tsconfig for entry point resolution, config inference, and watcher setup. [[1]](diffhunk://#diff-6508a5b483eb2d55fd58361931d864832b5ba20178c796d07be21f9e8ac327aeR176-R177) [[2]](diffhunk://#diff-6508a5b483eb2d55fd58361931d864832b5ba20178c796d07be21f9e8ac327aeL221-R220) [[3]](diffhunk://#diff-6508a5b483eb2d55fd58361931d864832b5ba20178c796d07be21f9e8ac327aeL230-R230) [[4]](diffhunk://#diff-6508a5b483eb2d55fd58361931d864832b5ba20178c796d07be21f9e8ac327aeL327-R326)
* Improved the federation tsconfig update logic to only include non-local entry points, avoiding unnecessary file writes and ensuring the config stays minimal and relevant. [[1]](diffhunk://#diff-5c22877eb7035e364eb495fd66443edff642a04a2c4b08c947707462fa25454cL22-R22) [[2]](diffhunk://#diff-5c22877eb7035e364eb495fd66443edff642a04a2c4b08c947707462fa25454cL84-R88) [[3]](diffhunk://#diff-a893764ac6ebee9697c07d4ca6460f4d860ef78b724cf5088a885747e74ef3efL8-R29) [[4]](diffhunk://#diff-a893764ac6ebee9697c07d4ca6460f4d860ef78b724cf5088a885747e74ef3efL40-L50)