### PR TITLE
fix(schematics/init): restore shareAll() call shape in federation.config.js template

### DIFF
--- a/packages/angular/src/schematics/init/files/federation.config.js__tmpl__
+++ b/packages/angular/src/schematics/init/files/federation.config.js__tmpl__
@@ -10,15 +10,16 @@ export default withNativeFederation({
   },
 <% } %>
   shared: {
-    ...shareAll({ 
+    ...shareAll(
       { singleton: true, strictVersion: true, requiredVersion: 'auto', build: 'package' },
       {
         overrides: {
-          '@angular/core': { singleton: true, strictVersion: true, requiredVersion: 'auto', build: 'package', includeSecondaries: {keepAll: true}},
-          '@angular/common': { singleton: true, strictVersion: true, requiredVersion: 'auto', build: 'package', chunks: true },
-        }
-      }
-    }),
+          // includeSecondaries is an opt-out of ignoreUnusedDeps, so all of
+          // @angular/core is shared to prevent mismatches.
+          '@angular/core': { singleton: true, strictVersion: true, requiredVersion: 'auto', build: 'package', includeSecondaries: { keepAll: true } },
+        },
+      },
+    ),
   },
 
   skip: [


### PR DESCRIPTION
Closes #33.

The `init` schematic emits a `federation.config.js` that calls `shareAll` with a single malformed argument:

```javascript
...shareAll({
  { singleton: true, ... },   // not valid inside {}
  { overrides: { ... } }
})
```

so the generated file does not parse. `shareAll` actually takes two positional arguments (default share config + options object), per the type signature in `packages/angular/src/config/share-utils.ts`. Drop the outer `{` / `}` so the template expands to a valid call.

While there, trim the `overrides` block to just `@angular/core` with `includeSecondaries: { keepAll: true }`, matching the "real shared object should be" snippet in the issue — the prior `@angular/common` override was redundant now that `ignoreUnusedDeps` is the default.

## Testing

Template-only change. No runtime code touched. The change is confined to `packages/angular/src/schematics/init/files/federation.config.js__tmpl__`, so a subsequent `nx generate` / `ng add` run will produce a parseable `federation.config.js`.