### PR TITLE
fix(angular-builder, pure vite): strip query string before resolving federation files in dev server

### DIFF
--- a/packages/angular/src/builders/build/builder.ts
+++ b/packages/angular/src/builders/build/builder.ts
@@ -17,36 +17,36 @@ import {
 import { normalizeOptions } from '@angular-devkit/build-angular/src/builders/dev-server/options.js';
 import type { Schema as DevServerSchema } from '@angular-devkit/build-angular/src/builders/dev-server/schema.js';
 
+import { type JsonObject } from '@angular-devkit/core';
 import {
   buildForFederation,
-  rebuildForFederation,
-  type FederationInfo,
-  type NormalizedFederationOptions,
-  getExternals,
-  normalizeFederationOptions,
-  setBuildAdapter,
   createFederationCache,
+  type FederationInfo,
+  getExternals,
+  type NormalizedFederationOptions,
+  normalizeFederationOptions,
+  rebuildForFederation,
+  setBuildAdapter,
 } from '@softarc/native-federation';
 import {
-  logger,
-  setLogLevel,
-  RebuildQueue,
   AbortedError,
-  getDefaultCachePath,
-  type NfFileWatcher,
-  syncNfFileWatcher,
   createNfWatcher,
+  getDefaultCachePath,
+  logger,
+  type NfFileWatcher,
+  RebuildQueue,
+  setLogLevel,
+  syncNfFileWatcher,
 } from '@softarc/native-federation/internal';
-import { createAngularBuildAdapter } from '../../utils/angular-esbuild-adapter.js';
-import { type JsonObject } from '@angular-devkit/core';
+import { type Plugin, type PluginBuild } from 'esbuild';
 import { existsSync, mkdirSync, rmSync } from 'fs';
 import { fstart } from '../../tools/fstart-as-data-url.js';
-import { type Plugin, type PluginBuild } from 'esbuild';
+import { createAngularBuildAdapter } from '../../utils/angular-esbuild-adapter.js';
 import { getI18nConfig, translateFederationArtifacts } from '../../utils/i18n.js';
 import { updateScriptTags } from '../../utils/update-index-html.js';
+import { checkForInvalidImports } from './../../utils/check-for-invalid-imports.js';
 import { federationBuildNotifier } from './federation-build-notifier.js';
 import type { NfBuilderSchema, NfInternalOptions } from './schema.js';
-import { checkForInvalidImports } from './../../utils/check-for-invalid-imports.js';
 
 const originalWrite = process.stderr.write.bind(process.stderr);
 
@@ -294,7 +294,9 @@ export async function* runBuilder(
       },
       next: () => void
     ) => {
-      const url = removeBaseHref(req, ngBuilderOptions.baseHref);
+      const rawUrl = removeBaseHref(req, ngBuilderOptions.baseHref);
+
+      const url = new URL(rawUrl || '/', 'http://localhost').pathname;
 
       const fileName = path.join(normalized.options.workspaceRoot, devServerOutputPath, url);
 

--- a/packages/angular/src/plugin/index.ts
+++ b/packages/angular/src/plugin/index.ts
@@ -1,15 +1,15 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import type { Plugin, ViteDevServer, IndexHtmlTransformResult, Connect } from 'vite';
-import { lookup } from 'mrmime';
-import { devExternalsMixin } from './dev-externals-mixin.js';
-import { filterExternals } from './externals-skip-list.js';
 import {
   type BuildHelperParams,
   federationBuilder,
   type FederationInfo,
 } from '@softarc/native-federation';
+import { lookup } from 'mrmime';
+import type { Connect, IndexHtmlTransformResult, Plugin, ViteDevServer } from 'vite';
+import { devExternalsMixin } from './dev-externals-mixin.js';
+import { filterExternals } from './externals-skip-list.js';
 
 type FedInfoRef = { federationInfo: FederationInfo };
 
@@ -71,15 +71,22 @@ const serveFromDist = (dist: string, fedInfoRef: FedInfoRef): Connect.NextHandle
   ]);
 
   return (req, res, next) => {
-    if (!req.url || req.url.endsWith('/index.html') || !fedFiles.has(req.url)) {
+    if (!req.url) {
       next();
       return;
     }
 
-    const file = path.join(dist, req.url);
+    const pathname = new URL(req.url, 'http://localhost').pathname;
+
+    if (pathname.endsWith('/index.html') || !fedFiles.has(pathname)) {
+      next();
+      return;
+    }
+
+    const file = path.join(dist, pathname);
     if (fs.existsSync(file) && fs.lstatSync(file).isFile()) {
       res.setHeader('Access-Control-Allow-Origin', '*');
-      const type = lookup(req.url) || '';
+      const type = lookup(pathname) || '';
       res.setHeader('Content-Type', type);
 
       const content = fs.readFileSync(file, 'utf-8');


### PR DESCRIPTION
Fixes #41 

Both dev-server middlewares used `req.url` directly when looking up federation files, which includes any query string. As a result, requests issued by the runtime with a `cacheTag` (e.g. `/remoteEntry.json?t=1777214450033`) never matched a known file path and fell through to Vite, returning `404`.

This PR parses the incoming URL once and uses only `URL.pathname` for both the file-set membership check and `path.join(...)` resolution. Query strings and fragments are now ignored, matching the behavior of any production static file server.


## Important note

I have tested this in an Angular setup and it works as expected, but I have not tested the pure Vite part