### PR TITLE
fix: issue where esbuild plugins werent applied properly

### DIFF
--- a/packages/angular/src/builders/build/builder.ts
+++ b/packages/angular/src/builders/build/builder.ts
@@ -179,7 +179,13 @@ export async function* runBuilder(
       ? nfBuilderOptions.tsConfig
       : ngBuilderOptions.tsConfig;
 
-  const adapter = createAngularBuildAdapter(ngBuilderOptions, context);
+  const adapter = createAngularBuildAdapter(
+    {
+      ...ngBuilderOptions,
+      plugins: nfBuilderOptions.plugins,
+    },
+    context
+  );
 
   setBuildAdapter(adapter);
 

--- a/packages/angular/src/builders/build/schema.d.ts
+++ b/packages/angular/src/builders/build/schema.d.ts
@@ -22,4 +22,4 @@ export interface NfBuilderSchema extends JsonObject {
   cacheExternalArtifacts?: boolean;
 }
 
-export type NfInternalOptions = { plugins: Plugin[] };
+export type NfInternalOptions = { plugins?: Plugin[] };

--- a/packages/angular/src/config/angular-skip-list.ts
+++ b/packages/angular/src/config/angular-skip-list.ts
@@ -3,6 +3,9 @@ import { type SkipList, DEFAULT_SKIP_LIST } from '@softarc/native-federation/con
 export const NG_SKIP_LIST: SkipList = [
   ...DEFAULT_SKIP_LIST,
   '@angular-architects/native-federation',
+  '@angular-architects/native-federation-v4',
+  '@angular-architects/native-federation-v4/config',
+  '@angular-architects/native-federation-v4/internal',
   'zone.js',
   '@angular/localize',
   '@angular/localize/init',

--- a/packages/angular/src/utils/angular-bundler.ts
+++ b/packages/angular/src/utils/angular-bundler.ts
@@ -135,6 +135,10 @@ export async function createAngularEsbuildContext(options: NormalizedContextOpti
     stylesheetBundlerOptions
   );
 
+  const customPlugins = Array.isArray(options.builderOptions.plugins)
+    ? options.builderOptions.plugins
+    : [];
+
   const config: esbuild.BuildOptions = {
     entryPoints: entryPoints.map(ep => ({
       in: ep.fileName,
@@ -157,7 +161,7 @@ export async function createAngularEsbuildContext(options: NormalizedContextOpti
     format: 'esm',
     target: target,
     logLimit: 0,
-    plugins: [compilerPlugin, commonjsPlugin()],
+    plugins: [compilerPlugin, commonjsPlugin(), ...customPlugins],
     define: {
       ngDevMode: dev ? 'true' : 'false',
       ngJitMode: 'false',

--- a/packages/angular/src/utils/angular-esbuild-adapter.ts
+++ b/packages/angular/src/utils/angular-esbuild-adapter.ts
@@ -16,6 +16,7 @@ import type { ApplicationBuilderOptions } from '@angular/build';
 import { createAngularEsbuildContext } from './angular-bundler.js';
 import { createNodeModulesEsbuildContext } from './node-modules-bundler.js';
 import { normalizeContextOptions } from './normalize-context-options.js';
+import type { NfInternalOptions } from '../builders/build/schema.js';
 
 export interface EsbuildContextResult extends NFBuildAdapterContext<esbuild.BuildContext> {
   pluginDisposed: Promise<void>;
@@ -59,7 +60,7 @@ function setNgServerMode(): void {
 }
 
 export function createAngularBuildAdapter(
-  ngBuilderOptions: ApplicationBuilderOptions,
+  ngBuilderOptions: ApplicationBuilderOptions & NfInternalOptions,
   context: BuilderContext
 ): NFBuildAdapter {
   const bundleContextCache = new Map<string, EsbuildContextResult>();

--- a/packages/angular/src/utils/node-modules-bundler.ts
+++ b/packages/angular/src/utils/node-modules-bundler.ts
@@ -109,6 +109,10 @@ export async function createNodeModulesEsbuildContext(options: NormalizedContext
   const commonjsPluginModule = await import('@chialab/esbuild-plugin-commonjs');
   const commonjsPlugin = commonjsPluginModule.default;
 
+  const customPlugins = Array.isArray(options.builderOptions.plugins)
+    ? options.builderOptions.plugins
+    : [];
+
   // Create JavaScriptTransformer for handling Angular partial compilation linking
   const advancedOptimizations = !dev;
   const jsTransformerCacheStore = getOrCreateJsTransformerCacheStore(cache.cachePath);
@@ -146,7 +150,11 @@ export async function createNodeModulesEsbuildContext(options: NormalizedContext
     format: 'esm',
     target: target,
     logLimit: 1,
-    plugins: [createAngularLinkerPlugin(jsTransformer, advancedOptimizations), commonjsPlugin()],
+    plugins: [
+      createAngularLinkerPlugin(jsTransformer, advancedOptimizations),
+      commonjsPlugin(),
+      ...customPlugins,
+    ],
     define: {
       ngDevMode: dev ? 'true' : 'false',
       ngJitMode: 'false',

--- a/packages/angular/src/utils/normalize-context-options.ts
+++ b/packages/angular/src/utils/normalize-context-options.ts
@@ -7,9 +7,10 @@ import type {
   NFBuildAdapterOptions,
 } from '@softarc/native-federation';
 import type { PathToImport } from '@softarc/native-federation/internal';
+import type { NfInternalOptions } from '../builders/build/schema';
 
 export interface NormalizedContextOptions {
-  builderOptions: ApplicationBuilderOptions;
+  builderOptions: ApplicationBuilderOptions & NfInternalOptions;
   context: BuilderContext;
   entryPoints: EntryPoint[];
   external: string[];
@@ -26,7 +27,7 @@ export interface NormalizedContextOptions {
 }
 
 export function normalizeContextOptions(
-  builderOptions: ApplicationBuilderOptions,
+  builderOptions: ApplicationBuilderOptions & NfInternalOptions,
   context: BuilderContext,
   adapterOptions: NFBuildAdapterOptions<SourceFileCache>
 ): NormalizedContextOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  lodash: ^4.18.0
-  minimatch: ^7.4.8
-
 importers:
 
   .:
@@ -3406,6 +3402,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
     peerDependencies:
@@ -3462,8 +3462,15 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3634,6 +3641,9 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   connect-history-api-fallback@2.0.0:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
@@ -4835,6 +4845,9 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -4967,6 +4980,21 @@ packages:
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@7.4.6:
+    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
+    engines: {node: '>=10'}
 
   minimatch@7.4.9:
     resolution: {integrity: sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw==}
@@ -7869,7 +7897,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 7.4.9
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -7890,7 +7918,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 7.4.9
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -8356,7 +8384,7 @@ snapshots:
       '@zkochan/js-yaml': 0.0.7
       ejs: 5.0.1
       enquirer: 2.3.6
-      minimatch: 7.4.9
+      minimatch: 10.2.4
       nx: 22.6.5(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.32(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.32(@swc/helpers@0.5.21))
       semver: 7.7.4
       tslib: 2.8.1
@@ -9263,7 +9291,7 @@ snapshots:
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
-      minimatch: 7.4.9
+      minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -9313,7 +9341,7 @@ snapshots:
       ajv: 8.17.1
       http-errors: 2.0.0
       http-status-codes: 2.3.0
-      minimatch: 7.4.9
+      minimatch: 7.4.6
       process-warning: 1.0.0
       semver: 7.7.2
 
@@ -9359,7 +9387,7 @@ snapshots:
       '@verdaccio/streams': 10.2.1
       async: 3.2.6
       debug: 4.4.1
-      lodash: 4.18.1
+      lodash: 4.17.21
       lowdb: 1.0.0
       mkdirp: 1.0.4
     transitivePeerDependencies:
@@ -9863,6 +9891,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.8.2: {}
 
   base64-js@1.5.1: {}
@@ -9931,9 +9961,18 @@ snapshots:
 
   boolbase@1.0.0: {}
 
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -10115,6 +10154,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  concat-map@0.0.1: {}
 
   connect-history-api-fallback@2.0.0: {}
 
@@ -10566,7 +10607,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 7.4.9
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -11390,6 +11431,8 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
+  lodash@4.17.21: {}
+
   lodash@4.18.1: {}
 
   log-symbols@4.1.0:
@@ -11515,6 +11558,22 @@ snapshots:
       webpack: 5.105.2(@swc/core@1.15.32(@swc/helpers@0.5.21))(esbuild@0.28.0)
 
   minimalistic-assert@1.0.1: {}
+
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
+  minimatch@7.4.6:
+    dependencies:
+      brace-expansion: 2.1.0
 
   minimatch@7.4.9:
     dependencies:
@@ -11647,7 +11706,7 @@ snapshots:
       jest-diff: 30.3.0
       jsonc-parser: 3.2.0
       lines-and-columns: 2.0.3
-      minimatch: 7.4.9
+      minimatch: 10.2.4
       npm-run-path: 4.0.1
       open: 8.4.2
       ora: 5.3.0


### PR DESCRIPTION
Closes #48 

This pull request introduces support for custom esbuild plugins in the Angular build process and updates the skip list for Angular federation. It also makes several internal type improvements to ensure plugin options are passed correctly throughout the build pipeline.

**Support for custom esbuild plugins and skip list updates:**

* The Angular builder now allows passing custom esbuild plugins via the `plugins` option. These plugins are injected into both the main application and node modules esbuild contexts, enabling advanced customization of the build process. [[1]](diffhunk://#diff-6508a5b483eb2d55fd58361931d864832b5ba20178c796d07be21f9e8ac327aeL182-R188) [[2]](diffhunk://#diff-5c22877eb7035e364eb495fd66443edff642a04a2c4b08c947707462fa25454cR138-R141) [[3]](diffhunk://#diff-5c22877eb7035e364eb495fd66443edff642a04a2c4b08c947707462fa25454cL160-R164) [[4]](diffhunk://#diff-c662f2399ef1cd014732edd2779dfee2b2fe74371b7118c82547f053be153cc9R112-R115) [[5]](diffhunk://#diff-c662f2399ef1cd014732edd2779dfee2b2fe74371b7118c82547f053be153cc9L149-R157)
* The Angular federation skip list (`NG_SKIP_LIST`) is updated to include additional packages related to `@angular-architects/native-federation-v4`, ensuring they are excluded from the bundle as intended.

**Type and internal API improvements:**

* Internal types (`ApplicationBuilderOptions` and `NfInternalOptions`) are unified and propagated, ensuring that custom plugin options are available throughout the build adapter and normalization logic. [[1]](diffhunk://#diff-cdd189e4a7fef21b3368959d680a9313fce666d6df687e977e66d625ceaa793eR19) [[2]](diffhunk://#diff-cdd189e4a7fef21b3368959d680a9313fce666d6df687e977e66d625ceaa793eL62-R63) [[3]](diffhunk://#diff-10df0428508753a1dd6c764ab5cc330cf1ba717cf297aba1c82bf9bcd25c096cR10-R13) [[4]](diffhunk://#diff-10df0428508753a1dd6c764ab5cc330cf1ba717cf297aba1c82bf9bcd25c096cL29-R30)
