### PR TITLE
feat: ability to use generated integrity for polyfill and main scripts

### DIFF
--- a/packages/angular/src/utils/update-index-html.ts
+++ b/packages/angular/src/utils/update-index-html.ts
@@ -34,17 +34,21 @@ export function updateScriptTags(indexContent: string, nfOptions: NfBuilderSchem
     ...nfOptions.esmsInitOptions,
   };
 
-  const htmlFragment = `
-<script type="esms-options">${JSON.stringify(esmsOptions)}</script>
-`;
+  const htmlFragment = `<script type="esms-options">${JSON.stringify(esmsOptions)}</script>`;
 
   indexContent = indexContent.replace(
-    /<script\s+src="([^"]*polyfills[^"]*)"[^>]*><\/script>/,
-    '<script type="module" src="$1"></script>'
+    /<script\b(?=[^>]*\bsrc="[^"]*polyfills[^"]*")[^>]*>/,
+    tag =>
+      /\btype\s*=/.test(tag)
+        ? tag.replace(/\btype\s*=\s*"[^"]*"/, 'type="module"')
+        : tag.replace(/<script\b/, '<script type="module"')
   );
   indexContent = indexContent.replace(
-    /<script\s+src="([^"]*main[^"]*)"[^>]*><\/script>/,
-    '<script type="module-shim" src="$1"></script>'
+    /<script\b(?=[^>]*\bsrc="[^"]*main[^"]*")[^>]*>/,
+    tag =>
+      /\btype\s*=/.test(tag)
+        ? tag.replace(/\btype\s*=\s*"[^"]*"/, 'type="module-shim"')
+        : tag.replace(/<script\b/, '<script type="module-shim"')
   );
 
   indexContent = indexContent.replace(/(<body.*?>)/, `$1\n\t\t${htmlFragment}`);


### PR DESCRIPTION
When enabling **subresourceIntegrity** option in Angular Builder, it will generate hashes for polyfills.js and main.js scripts. But the Native Federation replace those tags without reusing the existing attributes such as crossorigin and integrity.

This PR is to add back the generated attributes from Angular Builder and just let the Native Federation replace the value of the "type" attribute only.

SRI is required to meet PCI DSS compliance.