### PR TITLE
fix: passthrough sse option to orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,17 @@ This option was introduced with version 19.0.14.
 
 Native Federation provides automatic shell reloading when remote Micro Frontends finish rebuilding during development. This feature eliminates manual page refreshes and significantly improves the development experience when working with multiple applications simultaneously.
 
+Pass `{ sse: true }` to `initFederation` to enable it:
+
+```typescript
+import { initFederation } from '@angular-architects/native-federation';
+
+initFederation('/assets/federation.manifest.json', { sse: true })
+  .catch(err => console.error(err))
+  .then(_ => import('./bootstrap'))
+  .catch(err => console.error(err));
+```
+
 For complete implementation details, configuration options, please refer to the article:
 
 **📖 [Fixing DX Friction: Automatic Shell Reloading in Native Federation](https://www.angulararchitects.io/en/blog/fixing-dx-friction-automatic-shell-reloading-in-native-federation/)**

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -384,6 +384,17 @@ This option was introduced with version 19.0.14.
 
 Native Federation provides automatic shell reloading when remote Micro Frontends finish rebuilding during development. This feature eliminates manual page refreshes and significantly improves the development experience when working with multiple applications simultaneously.
 
+Pass `{ sse: true }` to `initFederation` to enable it:
+
+```typescript
+import { initFederation } from '@angular-architects/native-federation';
+
+initFederation('/assets/federation.manifest.json', { sse: true })
+  .catch(err => console.error(err))
+  .then(_ => import('./bootstrap'))
+  .catch(err => console.error(err));
+```
+
 For complete implementation details, configuration options, please refer to the article:
 
 **📖 [Fixing DX Friction: Automatic Shell Reloading in Native Federation](https://www.angulararchitects.io/en/blog/fixing-dx-friction-automatic-shell-reloading-in-native-federation/)**

--- a/packages/angular/src/index.spec.ts
+++ b/packages/angular/src/index.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockInitFederation = vi.fn();
+const mockUseShimImportMap = vi.fn();
+const mockConsoleLogger = vi.fn();
+const mockGlobalThisStorageEntry = vi.fn();
+
+vi.mock('@softarc/native-federation-orchestrator', () => ({
+  initFederation: mockInitFederation,
+  NativeFederationResult: undefined,
+}));
+
+vi.mock('@softarc/native-federation-orchestrator/options', () => ({
+  useShimImportMap: mockUseShimImportMap,
+  consoleLogger: mockConsoleLogger,
+  globalThisStorageEntry: mockGlobalThisStorageEntry,
+  LogType: undefined,
+}));
+
+describe('initFederation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockInitFederation.mockReset();
+    mockUseShimImportMap.mockReset();
+    mockConsoleLogger.mockReset();
+    mockGlobalThisStorageEntry.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('passes sse: true to orchestrator when options.sse is true', async () => {
+    mockInitFederation.mockReturnValue(Promise.resolve({}));
+    mockUseShimImportMap.mockReturnValue({});
+    const { initFederation } = await import('./index.js');
+
+    initFederation({}, { sse: true });
+
+    const options = mockInitFederation.mock.calls[0][1];
+    expect(options.sse).toBe(true);
+  });
+
+  it('passes sse: false to orchestrator when options.sse is false', async () => {
+    mockInitFederation.mockReturnValue(Promise.resolve({}));
+    mockUseShimImportMap.mockReturnValue({});
+    const { initFederation } = await import('./index.js');
+
+    initFederation({}, { sse: false });
+
+    const options = mockInitFederation.mock.calls[0][1];
+    expect(options.sse).toBe(false);
+  });
+
+  it('passes sse: undefined to orchestrator when options.sse is not set', async () => {
+    mockInitFederation.mockReturnValue(Promise.resolve({}));
+    mockUseShimImportMap.mockReturnValue({});
+    const { initFederation } = await import('./index.js');
+
+    initFederation({}, {});
+
+    const options = mockInitFederation.mock.calls[0][1];
+    expect(options.sse).toBeUndefined();
+  });
+
+  it('does not pass sse when options is omitted', async () => {
+    mockInitFederation.mockReturnValue(Promise.resolve({}));
+    mockUseShimImportMap.mockReturnValue({});
+    const { initFederation } = await import('./index.js');
+
+    initFederation({});
+
+    const options = mockInitFederation.mock.calls[0][1];
+    expect(options.sse).toBeUndefined();
+  });
+});

--- a/packages/angular/src/index.spec.ts
+++ b/packages/angular/src/index.spec.ts
@@ -37,7 +37,7 @@ describe('initFederation', () => {
 
     initFederation({}, { sse: true });
 
-    const options = mockInitFederation.mock.calls[0][1];
+    const options = mockInitFederation.mock.calls[0]![1];
     expect(options.sse).toBe(true);
   });
 
@@ -48,7 +48,7 @@ describe('initFederation', () => {
 
     initFederation({}, { sse: false });
 
-    const options = mockInitFederation.mock.calls[0][1];
+    const options = mockInitFederation.mock.calls[0]![1];
     expect(options.sse).toBe(false);
   });
 
@@ -59,7 +59,7 @@ describe('initFederation', () => {
 
     initFederation({}, {});
 
-    const options = mockInitFederation.mock.calls[0][1];
+    const options = mockInitFederation.mock.calls[0]![1];
     expect(options.sse).toBeUndefined();
   });
 
@@ -70,7 +70,7 @@ describe('initFederation', () => {
 
     initFederation({});
 
-    const options = mockInitFederation.mock.calls[0][1];
+    const options = mockInitFederation.mock.calls[0]![1];
     expect(options.sse).toBeUndefined();
   });
 });

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -40,6 +40,7 @@ export type LoadRemoteModuleOptions<T = any> = {
 export interface InitFederationOptions {
   cacheTag?: string;
   logging?: LogType;
+  sse?: boolean;
 }
 
 let resolveFirstInit!: (
@@ -64,6 +65,7 @@ export function initFederation(
     storage: globalThisStorageEntry,
     hostRemoteEntry: { url: './remoteEntry.json', cacheTag: options?.cacheTag },
     logLevel: options?.logging ?? 'debug',
+    sse: options?.sse,
   });
   if (!firstInitCaptured) {
     firstInitCaptured = true;


### PR DESCRIPTION
The `InitFederationOptions` interface defines `cacheTag` and `logging` but was missing `sse`, even though the orchestrator supports it. Without it, the shell-reloading feature documented in the README could not actually be enabled.

I was not sure on where to document this and whether to add unit tests for it, so in case that's not write just give me a hint.
