### PR TITLE
feat: allow opting out of es-module-shims shim mode (native import maps)

### DIFF
--- a/src/builders/build/update-index-html.spec.ts
+++ b/src/builders/build/update-index-html.spec.ts
@@ -22,6 +22,15 @@ describe('updateScriptTags', () => {
     );
   });
 
+  it('keeps the main script a plain module when shimMode is disabled', () => {
+    const html = '<body><script src="main-XYZ.js"></script></body>';
+    const result = updateScriptTags(html, {
+      esmsInitOptions: { shimMode: false },
+    } as never);
+    expect(result).toContain('<script type="module" src="main-XYZ.js"></script>');
+    expect(result).not.toContain('module-shim');
+  });
+
   it('replaces an existing type attribute rather than appending one', () => {
     const html = '<body><script type="text/javascript" src="main-XYZ.js"></script></body>';
     const result = updateScriptTags(html, nfOptions);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockInitFederation = vi.fn();
 const mockUseShimImportMap = vi.fn();
+const mockUseDefaultImportMap = vi.fn();
 const mockConsoleLogger = vi.fn();
 const mockGlobalThisStorageEntry = vi.fn();
 
@@ -12,6 +13,7 @@ vi.mock('@softarc/native-federation-orchestrator', () => ({
 
 vi.mock('@softarc/native-federation-orchestrator/options', () => ({
   useShimImportMap: mockUseShimImportMap,
+  useDefaultImportMap: mockUseDefaultImportMap,
   consoleLogger: mockConsoleLogger,
   globalThisStorageEntry: mockGlobalThisStorageEntry,
   LogType: undefined,
@@ -22,6 +24,7 @@ describe('initFederation', () => {
     vi.resetModules();
     mockInitFederation.mockReset();
     mockUseShimImportMap.mockReset();
+    mockUseDefaultImportMap.mockReset();
     mockConsoleLogger.mockReset();
     mockGlobalThisStorageEntry.mockReset();
   });
@@ -72,5 +75,41 @@ describe('initFederation', () => {
 
     const options = mockInitFederation.mock.calls[0]![1];
     expect(options.sse).toBeUndefined();
+  });
+
+  it('uses the shim import map by default', async () => {
+    mockInitFederation.mockReturnValue(Promise.resolve({}));
+    mockUseShimImportMap.mockReturnValue({});
+    mockUseDefaultImportMap.mockReturnValue({});
+    const { initFederation } = await import('./index.js');
+
+    initFederation({});
+
+    expect(mockUseShimImportMap).toHaveBeenCalledWith({ shimMode: true });
+    expect(mockUseDefaultImportMap).not.toHaveBeenCalled();
+  });
+
+  it('uses native import maps when shimMode is false', async () => {
+    mockInitFederation.mockReturnValue(Promise.resolve({}));
+    mockUseShimImportMap.mockReturnValue({});
+    mockUseDefaultImportMap.mockReturnValue({});
+    const { initFederation } = await import('./index.js');
+
+    initFederation({}, { shimMode: false });
+
+    expect(mockUseDefaultImportMap).toHaveBeenCalledTimes(1);
+    expect(mockUseShimImportMap).not.toHaveBeenCalled();
+  });
+
+  it('uses the shim import map when shimMode is true', async () => {
+    mockInitFederation.mockReturnValue(Promise.resolve({}));
+    mockUseShimImportMap.mockReturnValue({});
+    mockUseDefaultImportMap.mockReturnValue({});
+    const { initFederation } = await import('./index.js');
+
+    initFederation({}, { shimMode: true });
+
+    expect(mockUseShimImportMap).toHaveBeenCalledWith({ shimMode: true });
+    expect(mockUseDefaultImportMap).not.toHaveBeenCalled();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,6 @@ export function initFederation(
   remotesOrManifestUrl?: Record<string, string> | string,
   options?: InitFederationOptions
 ) {
-  // `shimMode: false` opts into native import maps instead of es-module-shims.
   const importMapProvider =
     options?.shimMode === false
       ? useDefaultImportMap()

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@softarc/native-federation-orchestrator';
 import {
   useShimImportMap,
+  useDefaultImportMap,
   consoleLogger,
   globalThisStorageEntry,
   type LogType,
@@ -41,6 +42,12 @@ export interface InitFederationOptions {
   cacheTag?: string;
   logging?: LogType;
   sse?: boolean;
+  /**
+   * Use es-module-shims shim mode (default `true`). Set `false` for native
+   * import maps; the build option `esmsInitOptions: { shimMode: false }` must
+   * match. See #70 for when native mode is needed (e.g. DevExtreme).
+   */
+  shimMode?: boolean;
 }
 
 let resolveFirstInit!: (
@@ -59,8 +66,13 @@ export function initFederation(
   remotesOrManifestUrl?: Record<string, string> | string,
   options?: InitFederationOptions
 ) {
+  // `shimMode: false` opts into native import maps instead of es-module-shims.
+  const importMapProvider =
+    options?.shimMode === false
+      ? useDefaultImportMap()
+      : useShimImportMap({ shimMode: true });
   const p = internalInitFederation(remotesOrManifestUrl ?? {}, {
-    ...useShimImportMap({ shimMode: true }),
+    ...importMapProvider,
     logger: consoleLogger,
     storage: globalThisStorageEntry,
     hostRemoteEntry: { url: './remoteEntry.json', cacheTag: options?.cacheTag },


### PR DESCRIPTION
Closes #70

## Motivation

`initFederation` hardcodes es-module-shims **shim mode**, and the index-html transform always rewrites the host entry to `type="module-shim"`. This routes the **entire host** through es-module-shims, which lexes every module and rewrites each `import(...)` into `importShim(...)`.

`es-module-lexer` can't tell a **method literally named `import`** from a dynamic `import()` call, so a host that bundles such a method gets rewritten into invalid JS and throws a `SyntaxError` that breaks the whole app. A real-world trigger is [**DevExtreme**](https://github.com/DevExpress/DevExtreme), whose Diagram widget declares `import(data, updateExistingItemsOnly) { ... }`. This is a lexer limitation, not a version issue — `es-module-lexer@2.1.0` and `es-module-shims@2.8.1` (both latest) still misparse it, so no upgrade fixes it. See #70 for the full analysis and repro.

## What this changes

Makes shim mode **opt-out**, defaulting to `true` — fully backward compatible. The orchestrator already exposes a native strategy (`useDefaultImportMap`); this just surfaces it through the adapter.

- **Runtime** (`src/index.ts`): `initFederation(remotes, { shimMode: false })` selects `useDefaultImportMap()` (native import maps + native `import()`) instead of `useShimImportMap`. New `InitFederationOptions.shimMode?: boolean`.
- **Build** (`src/builders/build/update-index-html.ts`): when `esmsInitOptions.shimMode === false`, the host entry stays `type="module"` instead of `type="module-shim"`, so es-module-shims never processes the host.

With shim mode off, the browser parses the host natively and the `import`-named method is handled correctly.

## Usage

```ts
// main.ts
initFederation('/assets/federation.manifest.json', { shimMode: false })
  .then(({ loadRemoteModule }) => /* ... */);
```

```jsonc
// angular.json / project.json — build + serve options
"esmsInitOptions": { "shimMode": false }
```

> Both options must agree: `shimMode: false` at runtime needs `esmsInitOptions: { shimMode: false }` in the build options so the entry script type matches.

## Browser support

Native mode relies on runtime/multiple import-map support: **Chrome/Edge 133+, Safari 18.4+, Firefox 150+** (behind `dom.multiple_import_maps.enabled`). Shim mode remains the default for broad compatibility.
Details available here: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#browser_compatibility

## Backward compatibility

None. `shimMode` defaults to `true`; existing setups are unaffected (verified by the existing tests, which still assert the shim-mode behavior).

## Tests

- `src/index.spec.ts`: default uses `useShimImportMap({ shimMode: true })`; `{ shimMode: false }` uses `useDefaultImportMap` and not the shim map; `{ shimMode: true }` uses the shim map.
- `src/builders/build/update-index-html.spec.ts`: with `esmsInitOptions: { shimMode: false }` the main script stays `type="module"`.

`pnpm typecheck`, `pnpm build`, `pnpm lint` (0 errors), and `pnpm test` (88 passing) all green.

## AI Usage Disclosure

The model used in this change was Claude Opus 4.8