### PR TITLE
fix: Disabled optimize-chunks since it messes with the generated remoteEntry.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 4.2.0(typescript@6.0.3)
       '@softarc/native-federation-orchestrator':
         specifier: ^4.2.2
-        version: 4.3.0
+        version: 4.3.1
       es-module-shims:
         specifier: ^2.8.0
         version: 2.8.1
@@ -1536,8 +1536,8 @@ packages:
     resolution: {integrity: sha512-iAUqIoRcK1CCHDm5E4Q1SI7rpVtsHJ+0qv5ll72wV3C1eCNdeDuGV0lX7PXEEkwd4y//s6yqI9o7f6VZZd6Fbw==, tarball: https://registry.npmjs.org/@schematics/angular/-/angular-22.0.3.tgz}
     engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
-  '@softarc/native-federation-orchestrator@4.3.0':
-    resolution: {integrity: sha512-PxqFMFA30mgdOi4NTqeqY1xCiBrJLG/p6x+MBjjMi+vhcSr6JdVxuC1aHYQh6qKB54542EmiXqkLgZ61SQYpBQ==, tarball: https://registry.npmjs.org/@softarc/native-federation-orchestrator/-/native-federation-orchestrator-4.3.0.tgz}
+  '@softarc/native-federation-orchestrator@4.3.1':
+    resolution: {integrity: sha512-QvOrXfm4u6un5dHE14Cm2HcEfKzGDjfztnHTkP0Fg7IrZpF2tw9lfhNEFuKXYejxLBNmcAn0lHkBVAcdx5MpHA==, tarball: https://registry.npmjs.org/@softarc/native-federation-orchestrator/-/native-federation-orchestrator-4.3.1.tgz}
     engines: {node: '>=22.14.0'}
 
   '@softarc/native-federation@4.2.0':
@@ -4210,7 +4210,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@softarc/native-federation-orchestrator@4.3.0':
+  '@softarc/native-federation-orchestrator@4.3.1':
     dependencies:
       semver: 7.8.5
 

--- a/src/builders/build/setup-builder-env-variables.ts
+++ b/src/builders/build/setup-builder-env-variables.ts
@@ -6,3 +6,13 @@
 if (!process.env['NG_BUILD_PARALLEL_TS']) {
   process.env['NG_BUILD_PARALLEL_TS'] = '0';
 }
+
+/**
+ * Disables Angular 22's chunk optimization pass (on by default, threshold 3).
+ * It re-bundles esbuild output via Rollup *after* Native Federation has already
+ * computed its import map, so shared externals (e.g. @angular/core) are no longer
+ * resolved as singletons in the optimized chunks. This surfaces at runtime as
+ * `ɵɵdefineComponent is not a function`. Setting this to '0' forces the threshold
+ * to Infinity, keeping federation's chunk layout intact.
+ */
+process.env['NG_BUILD_OPTIMIZE_CHUNKS'] = '0';

--- a/src/builders/remote/builder.ts
+++ b/src/builders/remote/builder.ts
@@ -1,4 +1,4 @@
-import '../build/setup-builder-env-variables.js';
+import './setup-builder-env-variables.js';
 
 import * as path from 'path';
 import { existsSync, mkdirSync, rmSync } from 'fs';

--- a/src/builders/remote/setup-builder-env-variables.ts
+++ b/src/builders/remote/setup-builder-env-variables.ts
@@ -1,0 +1,8 @@
+/**
+ * Disables Angular's parallel caching and allows for
+ * a shared cache between the compilation steps which
+ * improves performance dramatically.
+ */
+if (!process.env['NG_BUILD_PARALLEL_TS']) {
+  process.env['NG_BUILD_PARALLEL_TS'] = '0';
+}


### PR DESCRIPTION
Closes #71 

This pull request updates dependencies and refines the remote builder to improve reliability and maintainability. The most important changes are:

Dependency updates:
* Upgraded `@softarc/native-federation-orchestrator` from version 4.3.0 to 4.3.1 in `pnpm-lock.yaml`, ensuring the latest bug fixes and features are included. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL34-R34) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1539-R1540) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4213-R4213)

Build environment and Angular compatibility:
* Added `process.env["NG_BUILD_OPTIMIZE_CHUNKS"] = "0"` to `src/builders/build/setup-builder-env-variables.ts` to disable Angular 22's chunk optimization pass, preventing issues with module federation and singleton resolution.
* Ensured both `src/builders/build/setup-builder-env-variables.ts` and the new `src/builders/remote/setup-builder-env-variables.ts` set `NG_BUILD_PARALLEL_TS` to `"0"` for improved build performance and cache sharing. [[1]](diffhunk://#diff-4fb4f67f6236d212b7f1b866be88e24b4fe6a7ee50dc4f9b76674eb4e24651e6L6-R18) [[2]](diffhunk://#diff-8fd3d382cfd9f1c3f14563e08fa24daa84e4beffbcda461ead4db3cf319b0e65R1-R8)

Code style and maintainability:
* Standardized import statements in `src/builders/remote/builder.ts` to use double quotes and consistent formatting for improved readability. [[1]](diffhunk://#diff-93315f1dd360ab64a57fdd00c8be929af0a3194b7ad19d0c6f762f7d901c037bL1-R12) [[2]](diffhunk://#diff-93315f1dd360ab64a57fdd00c8be929af0a3194b7ad19d0c6f762f7d901c037bL17-R46)
* Refactored function calls and error messages in `src/builders/remote/builder.ts` for better clarity, parameter formatting, and consistency (e.g., using double quotes, improved async/await handling, and clearer error handling). [[1]](diffhunk://#diff-93315f1dd360ab64a57fdd00c8be929af0a3194b7ad19d0c6f762f7d901c037bL50-R73) [[2]](diffhunk://#diff-93315f1dd360ab64a57fdd00c8be929af0a3194b7ad19d0c6f762f7d901c037bL80-R118) [[3]](diffhunk://#diff-93315f1dd360ab64a57fdd00c8be929af0a3194b7ad19d0c6f762f7d901c037bL112-R132) [[4]](diffhunk://#diff-93315f1dd360ab64a57fdd00c8be929af0a3194b7ad19d0c6f762f7d901c037bL127-R159) [[5]](diffhunk://#diff-93315f1dd360ab64a57fdd00c8be929af0a3194b7ad19d0c6f762f7d901c037bL160-R189) [[6]](diffhunk://#diff-93315f1dd360ab64a57fdd00c8be929af0a3194b7ad19d0c6f762f7d901c037bL177-R251)…teEntry.json