### PR TITLE
feat: shareScope 'auto'

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,46 @@ export default withNativeFederation({
 
 When enabled, instead of listing each chunk as a separate shared dependency, chunks are grouped by bundle name in a dedicated `chunks` object. Each shared dependency gets a `bundle` property linking it to its chunk bundle. This results in a smaller `remoteEntry.json` and allows chunks to be skipped if the dependency is not used in the final import map.
 
+### Version-Pinned Share Scopes
+
+A `shareScope` isolates shared dependencies into a named bucket, so packages are only shared between remotes that use the same scope. The `autoShareScope` helper derives that name from a dependency's declared version, letting you pin sharing to a version line without hardcoding the number.
+
+```js
+import { withNativeFederation, shareAll, autoShareScope } from '@angular-architects/native-federation/config';
+
+export default withNativeFederation({
+  // Only share with remotes built against the same Angular minor, e.g. "ng21.1"
+  shareScope: autoShareScope(),
+
+  shared: {
+    ...shareAll({ singleton: true, strictVersion: true, requiredVersion: 'auto' }),
+  },
+});
+```
+
+The `level` option controls the granularity of the generated scope (given `@angular/core` is `21.1.4`):
+
+| `level`   | Result       |
+| --------- | ------------ |
+| `'major'` | `"ng21"`     |
+| `'minor'` | `"ng21.1"` (default) |
+| `'patch'` | `"ng21.1.4"` |
+
+You can also point it at another package or set a per-dependency scope:
+
+```js
+export default withNativeFederation({
+  shareScope: autoShareScope({ level: 'patch' }),
+
+  shared: {
+    // Override the scope for a single package
+    rxjs: { singleton: true, shareScope: autoShareScope({ dependency: 'rxjs' }) },
+  },
+});
+```
+
+The version is read from `dependencies`, `devDependencies` or `peerDependencies` in your `package.json`. `autoShareScope` throws if the dependency isn't declared, or if the declared version lacks enough segments for the requested `level`.
+
 ### SSR and Hydration
 
 We support Angular's SSR and (Incremental) Hydration. Please find [more information here](https://www.angulararchitects.io/blog/ssr-and-hydration-with-native-federation-for-angular/).

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,9 @@
-export { share, shareAll, withNativeFederation } from './config/share-utils.js';
+export {
+  share,
+  shareAll,
+  withNativeFederation,
+  autoShareScope,
+  type PackageShareScopeOptions,
+} from './config/share-utils.js';
 export { NG_SKIP_LIST } from './config/angular-skip-list.js';
 export { shareAngularLocales } from './config/angular-locales.js';

--- a/src/config/share-utils.spec.ts
+++ b/src/config/share-utils.spec.ts
@@ -3,6 +3,7 @@ import {
   shareAll,
   withNativeFederation,
   getDefaultPlatform,
+  getAngularShareScope,
   SERVER_DEPENDENCIES,
 } from './share-utils.js';
 import { NG_SKIP_LIST } from './angular-skip-list.js';
@@ -16,6 +17,16 @@ vi.mock('@softarc/native-federation/config', () => ({
   share: (...args: unknown[]) => mockCoreShare(...args),
   shareAll: (...args: unknown[]) => mockCoreShareAll(...args),
   withNativeFederation: (...args: unknown[]) => mockCoreWithNativeFederation(...args),
+}));
+
+const mockExistsSync = vi.fn((p: string) => p.endsWith('package.json'));
+const mockReadFileSync = vi.fn(() =>
+  JSON.stringify({ dependencies: { '@angular/core': '^21.1.4' } }),
+);
+
+vi.mock('node:fs', () => ({
+  existsSync: (...args: unknown[]) => mockExistsSync(...(args as [string])),
+  readFileSync: () => mockReadFileSync(),
 }));
 
 afterEach(() => {
@@ -137,6 +148,99 @@ describe('withNativeFederation', () => {
       '@angular/core',
       '@angular/common/locales/de',
     ]);
+  });
+});
+
+describe('getAngularShareScope', () => {
+  it('derives ng<major>.<minor> from the declared @angular/core version', () => {
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({ dependencies: { '@angular/core': '^21.1.4' } }),
+    );
+
+    expect(getAngularShareScope('/project')).toBe('ng21.1');
+  });
+
+  it('strips range prefixes and prerelease suffixes', () => {
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({ dependencies: { '@angular/core': '~22.0.0-next.3' } }),
+    );
+
+    expect(getAngularShareScope('/project')).toBe('ng22.0');
+  });
+
+  it('falls back to devDependencies and peerDependencies', () => {
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({ devDependencies: { '@angular/core': '20.2.1' } }),
+    );
+    expect(getAngularShareScope('/project')).toBe('ng20.2');
+
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({ peerDependencies: { '@angular/core': '19.0.0' } }),
+    );
+    expect(getAngularShareScope('/project')).toBe('ng19.0');
+  });
+
+  it('throws when @angular/core is not a declared dependency', () => {
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({ dependencies: { rxjs: '7.0.0' } }),
+    );
+
+    expect(() => getAngularShareScope('/project')).toThrow(/@angular\/core/);
+  });
+});
+
+describe('withNativeFederation shareScope: "auto"', () => {
+  beforeEach(() => {
+    mockCoreWithNativeFederation.mockReturnValue({
+      features: { ignoreUnusedDeps: true },
+      shared: {},
+    });
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ dependencies: { '@angular/core': '^21.1.4' } }),
+    );
+  });
+
+  it('resolves the top-level shareScope', () => {
+    withNativeFederation({ shareScope: 'auto', shared: {} } as never);
+
+    expect(mockCoreWithNativeFederation.mock.calls[0]![0].shareScope).toBe('ng21.1');
+  });
+
+  it('resolves per-external shareScope entries', () => {
+    withNativeFederation({
+      shared: {
+        '@angular/core': { shareScope: 'auto' },
+        rxjs: { shareScope: 'auto' },
+      },
+    } as never);
+
+    const passed = mockCoreWithNativeFederation.mock.calls[0]![0];
+    expect(passed.shared['@angular/core'].shareScope).toBe('ng21.1');
+    expect(passed.shared['rxjs'].shareScope).toBe('ng21.1');
+  });
+
+  it('leaves an explicitly configured shareScope untouched', () => {
+    withNativeFederation({
+      shareScope: 'custom',
+      shared: { rxjs: { shareScope: 'other' } },
+    } as never);
+
+    const passed = mockCoreWithNativeFederation.mock.calls[0]![0];
+    expect(passed.shareScope).toBe('custom');
+    expect(passed.shared['rxjs'].shareScope).toBe('other');
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it('reads package.json at most once regardless of how many entries use "auto"', () => {
+    withNativeFederation({
+      shareScope: 'auto',
+      shared: {
+        '@angular/core': { shareScope: 'auto' },
+        '@angular/common': { shareScope: 'auto' },
+      },
+    } as never);
+
+    expect(mockReadFileSync).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/config/share-utils.spec.ts
+++ b/src/config/share-utils.spec.ts
@@ -3,7 +3,7 @@ import {
   shareAll,
   withNativeFederation,
   getDefaultPlatform,
-  getAngularShareScope,
+  autoShareScope,
   SERVER_DEPENDENCIES,
 } from './share-utils.js';
 import { NG_SKIP_LIST } from './angular-skip-list.js';
@@ -151,13 +151,29 @@ describe('withNativeFederation', () => {
   });
 });
 
-describe('getAngularShareScope', () => {
-  it('derives ng<major>.<minor> from the declared @angular/core version', () => {
+describe('autoShareScope', () => {
+  it('derives ng<major>.<minor> from the declared @angular/core version by default', () => {
     mockReadFileSync.mockReturnValueOnce(
       JSON.stringify({ dependencies: { '@angular/core': '^21.1.4' } }),
     );
 
-    expect(getAngularShareScope('/project')).toBe('ng21.1');
+    expect(autoShareScope({ projectPath: '/project' })).toBe('ng21.1');
+  });
+
+  it('pins to the major version at level "major"', () => {
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({ dependencies: { '@angular/core': '^21.1.4' } }),
+    );
+
+    expect(autoShareScope({ level: 'major', projectPath: '/project' })).toBe('ng21');
+  });
+
+  it('pins to the patch version at level "patch"', () => {
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({ dependencies: { '@angular/core': '^21.1.4' } }),
+    );
+
+    expect(autoShareScope({ level: 'patch', projectPath: '/project' })).toBe('ng21.1.4');
   });
 
   it('strips range prefixes and prerelease suffixes', () => {
@@ -165,19 +181,23 @@ describe('getAngularShareScope', () => {
       JSON.stringify({ dependencies: { '@angular/core': '~22.0.0-next.3' } }),
     );
 
-    expect(getAngularShareScope('/project')).toBe('ng22.0');
+    expect(autoShareScope({ projectPath: '/project' })).toBe('ng22.0');
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({ dependencies: { '@angular/core': '~22.0.0-next.3' } }),
+    );
+    expect(autoShareScope({ level: 'patch', projectPath: '/project' })).toBe('ng22.0.0');
   });
 
   it('falls back to devDependencies and peerDependencies', () => {
     mockReadFileSync.mockReturnValueOnce(
       JSON.stringify({ devDependencies: { '@angular/core': '20.2.1' } }),
     );
-    expect(getAngularShareScope('/project')).toBe('ng20.2');
+    expect(autoShareScope({ projectPath: '/project' })).toBe('ng20.2');
 
     mockReadFileSync.mockReturnValueOnce(
       JSON.stringify({ peerDependencies: { '@angular/core': '19.0.0' } }),
     );
-    expect(getAngularShareScope('/project')).toBe('ng19.0');
+    expect(autoShareScope({ projectPath: '/project' })).toBe('ng19.0');
   });
 
   it('throws when @angular/core is not a declared dependency', () => {
@@ -185,62 +205,17 @@ describe('getAngularShareScope', () => {
       JSON.stringify({ dependencies: { rxjs: '7.0.0' } }),
     );
 
-    expect(() => getAngularShareScope('/project')).toThrow(/@angular\/core/);
+    expect(() => autoShareScope({ projectPath: '/project' })).toThrow(/@angular\/core/);
   });
-});
 
-describe('withNativeFederation shareScope: "auto"', () => {
-  beforeEach(() => {
-    mockCoreWithNativeFederation.mockReturnValue({
-      features: { ignoreUnusedDeps: true },
-      shared: {},
-    });
-    mockReadFileSync.mockReturnValue(
-      JSON.stringify({ dependencies: { '@angular/core': '^21.1.4' } }),
+  it('throws when the requested level has no matching version segment', () => {
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({ dependencies: { '@angular/core': '21' } }),
     );
-  });
 
-  it('resolves the top-level shareScope', () => {
-    withNativeFederation({ shareScope: 'auto', shared: {} } as never);
-
-    expect(mockCoreWithNativeFederation.mock.calls[0]![0].shareScope).toBe('ng21.1');
-  });
-
-  it('resolves per-external shareScope entries', () => {
-    withNativeFederation({
-      shared: {
-        '@angular/core': { shareScope: 'auto' },
-        rxjs: { shareScope: 'auto' },
-      },
-    } as never);
-
-    const passed = mockCoreWithNativeFederation.mock.calls[0]![0];
-    expect(passed.shared['@angular/core'].shareScope).toBe('ng21.1');
-    expect(passed.shared['rxjs'].shareScope).toBe('ng21.1');
-  });
-
-  it('leaves an explicitly configured shareScope untouched', () => {
-    withNativeFederation({
-      shareScope: 'custom',
-      shared: { rxjs: { shareScope: 'other' } },
-    } as never);
-
-    const passed = mockCoreWithNativeFederation.mock.calls[0]![0];
-    expect(passed.shareScope).toBe('custom');
-    expect(passed.shared['rxjs'].shareScope).toBe('other');
-    expect(mockReadFileSync).not.toHaveBeenCalled();
-  });
-
-  it('reads package.json at most once regardless of how many entries use "auto"', () => {
-    withNativeFederation({
-      shareScope: 'auto',
-      shared: {
-        '@angular/core': { shareScope: 'auto' },
-        '@angular/common': { shareScope: 'auto' },
-      },
-    } as never);
-
-    expect(mockReadFileSync).toHaveBeenCalledTimes(1);
+    expect(() => autoShareScope({ level: 'patch', projectPath: '/project' })).toThrow(
+      /patch/,
+    );
   });
 });
 

--- a/src/config/share-utils.ts
+++ b/src/config/share-utils.ts
@@ -11,6 +11,9 @@ import {
 } from "@softarc/native-federation/config";
 import { NG_SKIP_LIST } from "./angular-skip-list.js";
 import type { NormalizedSharedExternalsConfig } from "@softarc/native-federation/internal";
+import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+import { cwd } from "node:process";
 
 export function shareAll(
   config: ShareAllExternalsOptions,
@@ -35,6 +38,8 @@ export function share(
 export function withNativeFederation(cfg: FederationConfig) {
   if (!cfg.platform)
     cfg.platform = getDefaultPlatform(Object.keys(cfg.shared ?? {}));
+
+  resolveAutoShareScope(cfg);
 
   const normalized = coreWithNativeFederation(cfg);
 
@@ -61,6 +66,41 @@ export function getDefaultPlatform(deps: string[]): "browser" | "node" {
     SERVER_DEPENDENCIES.some((server) => dep.startsWith(server)),
   );
   return hasServerDep ? "node" : "browser";
+}
+
+export function getAngularShareScope(projectPath: string = cwd()): string {
+  let dir = projectPath;
+  while (
+    !existsSync(path.join(dir, "package.json")) &&
+    path.dirname(dir) !== dir
+  )
+    dir = path.dirname(dir);
+
+  const pkgPath = path.join(dir, "package.json");
+  const pkg = existsSync(pkgPath)
+    ? JSON.parse(readFileSync(pkgPath, "utf-8"))
+    : {};
+  const version =
+    pkg.dependencies?.["@angular/core"] ??
+    pkg.devDependencies?.["@angular/core"] ??
+    pkg.peerDependencies?.["@angular/core"];
+  const match = version ? /(\d+)\.(\d+)/.exec(version) : null;
+  if (!match)
+    throw new Error(
+      `shareScope:'auto' could not resolve an '@angular/core' version from ${pkgPath}`,
+    );
+
+  return `ng${match[1]}.${match[2]}`;
+}
+
+function resolveAutoShareScope(cfg: FederationConfig): void {
+  let scope: string | undefined;
+  const findAngularRange = () => (scope ??= getAngularShareScope());
+
+  if (cfg.shareScope === "auto") cfg.shareScope = findAngularRange();
+  for (const external of Object.values(cfg.shared ?? {}))
+    if (external?.shareScope === "auto")
+      external.shareScope = findAngularRange();
 }
 
 function removeNgLocales(

--- a/src/config/share-utils.ts
+++ b/src/config/share-utils.ts
@@ -39,8 +39,6 @@ export function withNativeFederation(cfg: FederationConfig) {
   if (!cfg.platform)
     cfg.platform = getDefaultPlatform(Object.keys(cfg.shared ?? {}));
 
-  resolveAutoShareScope(cfg);
-
   const normalized = coreWithNativeFederation(cfg);
 
   // This is for being backwards compatible
@@ -68,7 +66,37 @@ export function getDefaultPlatform(deps: string[]): "browser" | "node" {
   return hasServerDep ? "node" : "browser";
 }
 
-export function getAngularShareScope(projectPath: string = cwd()): string {
+export interface PackageShareScopeOptions {
+  level?: "major" | "minor" | "patch";
+  /** Package whose version drives the scope. Defaults to `@angular/core`. */
+  dependency?: string;
+  /** Directory to start resolving `package.json` from. Defaults to `cwd()`. */
+  projectPath?: string;
+  prefix?: string;
+}
+
+/**
+ * Builds a version-pinned share scope (e.g. `"ng21.1"`) from a dependency's
+ * declared version, so internals are only shared between remotes on the same
+ * version line.
+ *
+ * ```ts
+ * withNativeFederation({
+ *   shareScope: autoShareScope({ level: 'patch' }), // e.g. "ng21.1.4"
+ *   shared: { '@angular/core': { shareScope: autoShareScope() } }, // "ng21.1"
+ * });
+ * ```
+ *
+ * @throws when the version can't be resolved or lacks the requested `level`.
+ */
+export function autoShareScope(opts: PackageShareScopeOptions = {}): string {
+  const {
+    level = "minor",
+    projectPath = cwd(),
+    dependency = "@angular/core",
+    prefix = "ng",
+  } = opts;
+
   let dir = projectPath;
   while (
     !existsSync(path.join(dir, "package.json")) &&
@@ -81,26 +109,29 @@ export function getAngularShareScope(projectPath: string = cwd()): string {
     ? JSON.parse(readFileSync(pkgPath, "utf-8"))
     : {};
   const version =
-    pkg.dependencies?.["@angular/core"] ??
-    pkg.devDependencies?.["@angular/core"] ??
-    pkg.peerDependencies?.["@angular/core"];
-  const match = version ? /(\d+)\.(\d+)/.exec(version) : null;
+    pkg.dependencies?.[dependency] ??
+    pkg.devDependencies?.[dependency] ??
+    pkg.peerDependencies?.[dependency];
+  const match = version ? /(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(version) : null;
   if (!match)
     throw new Error(
-      `shareScope:'auto' could not resolve an '@angular/core' version from ${pkgPath}`,
+      `autoShareScope() could not resolve an '${dependency}' version from ${pkgPath}`,
     );
 
-  return `ng${match[1]}.${match[2]}`;
-}
-
-function resolveAutoShareScope(cfg: FederationConfig): void {
-  let scope: string | undefined;
-  const findAngularRange = () => (scope ??= getAngularShareScope());
-
-  if (cfg.shareScope === "auto") cfg.shareScope = findAngularRange();
-  for (const external of Object.values(cfg.shared ?? {}))
-    if (external?.shareScope === "auto")
-      external.shareScope = findAngularRange();
+  const [, major, minor, patch] = match;
+  if (level === "major") return `${prefix}${major}`;
+  if (level === "minor") {
+    if (minor === undefined)
+      throw new Error(
+        `autoShareScope({ level: 'minor' }) could not resolve a minor version from '${version}' in ${pkgPath}`,
+      );
+    return `${prefix}${major}.${minor}`;
+  }
+  if (minor === undefined || patch === undefined)
+    throw new Error(
+      `autoShareScope({ level: 'patch' }) could not resolve a patch version from '${version}' in ${pkgPath}`,
+    );
+  return `${prefix}${major}.${minor}.${patch}`;
 }
 
 function removeNgLocales(

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"fileNames":[],"fileInfos":[],"root":[],"options":{"composite":true,"declarationMap":true,"importHelpers":true,"module":199,"noEmitOnError":true,"noFallthroughCasesInSwitch":true,"noImplicitOverride":true,"noImplicitReturns":true,"noUncheckedIndexedAccess":true,"noUnusedLocals":true,"noUnusedParameters":true,"skipLibCheck":true,"strict":true,"target":99},"version":"6.0.3"}


### PR DESCRIPTION
closes #76 

This pull request introduces a new feature for version-pinned share scopes in module federation, allowing shared dependencies to be isolated by version using the new `autoShareScope` utility. This makes it easier to ensure that only compatible versions of dependencies are shared between remotes, reducing the risk of version conflicts. The implementation includes documentation, code, and comprehensive tests.

**Key changes:**

### New Feature: Version-Pinned Share Scopes

* Added the `autoShareScope` utility function and `PackageShareScopeOptions` type to `src/config/share-utils.ts`, enabling automatic generation of share scope names based on a dependency's version (e.g., `"ng21.1"`). This supports configurable granularity (`major`, `minor`, `patch`), custom dependency selection, and custom prefixes.

* Updated the documentation in `README.md` to describe the new version-pinned share scopes feature, including usage examples and configuration options.

### API and Exports

* Exported `autoShareScope` and `PackageShareScopeOptions` from the package entrypoint in `src/config.ts`.

### Testing

* Added comprehensive unit tests for `autoShareScope` in `src/config/share-utils.spec.ts`, covering version extraction, granularity options, dependency fallbacks, and error cases.
* Mocked Node.js `fs` methods in the test suite to simulate various `package.json` scenarios for robust test coverage.

### Miscellaneous

* Updated imports in relevant files to include the new utility. [[1]](diffhunk://#diff-3588bce34c4666fcbe396f65622c2bd6a809f4759eb2691893df81b87dedd917R6) [[2]](diffhunk://#diff-20bfa270ed9b865b41f4403f0934dca2ab3cfd76edb5f59ed941d2024fdfa85cR14-R16)
* Added a new `tsconfig.tsbuildinfo` artifact.