### PR TITLE
fix: Windows path bug in create-federation-tsconfig

### DIFF
--- a/src/tools/esbuild/create-federation-tsconfig.spec.ts
+++ b/src/tools/esbuild/create-federation-tsconfig.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import JSON5 from 'json5';
 
 import { updateFederationTsConfig } from './create-federation-tsconfig.js';
@@ -59,6 +60,22 @@ describe('updateFederationTsConfig', () => {
 
     const written = JSON.parse(String(vi.mocked(fs.writeFileSync).mock.calls[0]![1]));
     expect(written.include).toEqual(['src/a.ts']);
+  });
+
+  it('normalizes OS-specific backslash separators to forward slashes', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON5.stringify({ include: [] }) as never);
+    // Simulate Windows: path.relative returns single-backslash separators.
+    const relativeSpy = vi
+      .spyOn(path, 'relative')
+      .mockReturnValue('..\\libs\\shared\\src\\index.ts');
+
+    updateFederationTsConfig('/ws', 'tsconfig.fed.json', [entry('/libs/shared/src/index.ts')]);
+
+    const written = JSON.parse(String(vi.mocked(fs.writeFileSync).mock.calls[0]![1]));
+    expect(written.include).toEqual(['../libs/shared/src/index.ts']);
+
+    relativeSpy.mockRestore();
   });
 
   it('does not write when the resulting config is unchanged', () => {

--- a/src/tools/esbuild/create-federation-tsconfig.ts
+++ b/src/tools/esbuild/create-federation-tsconfig.ts
@@ -18,7 +18,7 @@ export function updateFederationTsConfig(
 
   const filtered = entryPoints
     .filter(ep => !ep.fileName.startsWith('.'))
-    .map(ep => path.relative(tsconfigDir, ep.fileName).replace(/\\\\/g, '/'));
+    .map(ep => path.relative(tsconfigDir, ep.fileName).replace(/\\/g, '/'));
 
   if (filtered.length === 0) {
     return;


### PR DESCRIPTION
Closes #78

This pull request improves the handling of file path separators in the `updateFederationTsConfig` utility to ensure cross-platform compatibility, particularly for Windows environments. It also adds a new test to verify this behavior.

**Cross-platform path normalization:**

* [`src/tools/esbuild/create-federation-tsconfig.ts`](diffhunk://#diff-5891865a3d05c45c6b6415687f2f1b7df7e2b2a635ad9901b43960eb34b5deccL21-R21): Fixed the path normalization logic to replace single backslashes (`This pull request improves the handling of file path separators in the `updateFederationTsConfig` utility to ensure cross-platform compatibility, particularly for Windows environments. It also adds a new test to verify this behavior.

**Cross-platform path normalization:**

) with forward slashes (`/`) when generating relative paths for the `include` field, ensuring compatibility across different operating systems.

**Testing improvements:**

* [`src/tools/esbuild/create-federation-tsconfig.spec.ts`](diffhunk://#diff-b05705cdf4caf0d41d8432b97cbc08223fcd552c13ab4ffe78bd5c74f77abe76R65-R80): Added a test case to verify that backslash path separators (common on Windows) are correctly normalized to forward slashes in the generated `tsconfig` includes.
* [`src/tools/esbuild/create-federation-tsconfig.spec.ts`](diffhunk://#diff-b05705cdf4caf0d41d8432b97cbc08223fcd552c13ab4ffe78bd5c74f77abe76R2): Added a missing import for the `path` module to support the new test.