### PR TITLE
fix: Passthrough of symlink to ESBuild context

### DIFF
--- a/src/tools/esbuild/angular-bundler.ts
+++ b/src/tools/esbuild/angular-bundler.ts
@@ -155,6 +155,7 @@ export async function createAngularEsbuildContext(options: NormalizedContextOpti
       'object-rest-spread': false,
     },
     splitting: chunks,
+    preserveSymlinks: builderOptions.preserveSymlinks,
     platform: platform ?? 'browser',
     format: 'esm',
     target: target,


### PR DESCRIPTION
Closes #86 

This pull request makes a targeted update to the Angular esbuild bundler to support preserving symlinks during the build process. This change allows the bundler to respect symbolic links in the project when the corresponding option is set.

Build configuration improvement:

* [`src/tools/esbuild/angular-bundler.ts`](diffhunk://#diff-6734ecf55a7ce6dd4ee5fcb2fc272a8f05ffdf86a8b8c2f43c4e0d3878ef024eR158): Added support for the `preserveSymlinks` option by passing `builderOptions.preserveSymlinks` to the esbuild configuration.