### PR TITLE
fix(builder): watch the files the federation build actually tracked

### DIFF
--- a/src/builders/build/builder.ts
+++ b/src/builders/build/builder.ts
@@ -50,6 +50,7 @@ import {
   describeFederationCache,
   federationSourceFiles,
 } from "./../../utils/federation-source-files.js";
+import { createStaleWatchEventFilter } from "./../../utils/stale-watch-event-filter.js";
 import { federationBuildNotifier } from "./federation-build-notifier.js";
 import type { NfBuilderSchema, NfInternalOptions } from "./schema.js";
 import { createAngularBuildAdapter } from "../../tools/esbuild/angular-esbuild-adapter.js";
@@ -446,7 +447,11 @@ export async function* runBuilder(
 
   // Watch what the federation compilation actually tracked — where the cache
   // records it depends on the TS compilation path; see federationSourceFiles.
+  // staleEvents guards the wide watch list: macOS FSEvents replays events for
+  // recently-edited files without a content change, and unguarded that replay
+  // wakes the loop forever (see stale-watch-event-filter.ts).
   const federationWatchedFiles = new Set<string>();
+  const staleEvents = createStaleWatchEventFilter();
   const syncFederationWatcher = (): void => {
     if (!nfWatcher) return;
     logger.verbose(
@@ -455,7 +460,13 @@ export async function* runBuilder(
     const files = federationSourceFiles(
       normalized.options.federationCache.bundlerCache,
     );
-    for (const file of files) federationWatchedFiles.add(path.normalize(file));
+    for (const file of files) {
+      const normalizedFile = path.normalize(file);
+      if (!federationWatchedFiles.has(normalizedFile)) {
+        federationWatchedFiles.add(normalizedFile);
+        staleEvents.seed(normalizedFile);
+      }
+    }
     syncNfFileWatcher(
       nfWatcher,
       { keys: () => files[Symbol.iterator]() },
@@ -470,6 +481,9 @@ export async function* runBuilder(
         // Coalesce ng-packagr's atomic multi-write bursts into one rebuild.
         debounceMs: 100,
         onChange: (p) => {
+          // Same-mtime replays never reach the dirty buffer — buffering them
+          // would rebuild federation outputs for files that did not change.
+          if (!staleEvents.isRealChange(p)) return;
           // Core stops filling the dirty buffer once onChange is set, so refill it
           // here (Set.add stays idempotent if core is later fixed). Wake the loop
           // for edits the Angular-driven rebuild will NOT cover: linked dirs and

--- a/src/builders/build/builder.ts
+++ b/src/builders/build/builder.ts
@@ -46,6 +46,10 @@ import {
 import { type Plugin, type PluginBuild } from "esbuild";
 import { devHostInstancesPlugin } from "../../plugin/dev-host-instances-plugin.js";
 import { checkForInvalidImports } from "./../../utils/check-for-invalid-imports.js";
+import {
+  describeFederationCache,
+  federationSourceFiles,
+} from "./../../utils/federation-source-files.js";
 import { federationBuildNotifier } from "./federation-build-notifier.js";
 import type { NfBuilderSchema, NfInternalOptions } from "./schema.js";
 import { createAngularBuildAdapter } from "../../tools/esbuild/angular-esbuild-adapter.js";
@@ -295,6 +299,16 @@ export async function* runBuilder(
   const start = process.hrtime();
   logger.measure(start, "To load the federation config.");
 
+  // Which TS compilation path the build takes is decided by module-load order:
+  // setup-builder-env-variables.ts sets NG_BUILD_PARALLEL_TS=0, but
+  // @angular/build captures it in a module-level const, so anything importing
+  // @angular/build first (common under Nx) wins. Pair this with the
+  // "SourceFileCache tracked files" line to see which path actually ran:
+  // outer=0 with typeScript>0 means the parallel path despite the env value.
+  logger.verbose(
+    `NG_BUILD_PARALLEL_TS=${process.env["NG_BUILD_PARALLEL_TS"] ?? "(unset)"}`,
+  );
+
   const externals = getExternals(normalized.config);
 
   // Realpath'd dirs of npm-linked shared packages (`[]` if none, making the
@@ -408,6 +422,11 @@ export async function* runBuilder(
 
   let first = true;
 
+  // Set when a watcher-driven federation rebuild completed and no Angular output
+  // has been consumed since; lets the loop skip the redundant Angular-driven
+  // rebuild that follows an ordinary save (the watcher usually wins that race).
+  let federationFresh = false;
+
   // A linked shared-package edit never makes Angular's iterator emit (it's an external),
   // so we wake the watch loop directly: notifyChange resolves changeSignal, which the
   // loop races against Angular's next output to drive a federation-only rebuild.
@@ -425,27 +444,14 @@ export async function* runBuilder(
   const isUnderLinkedDir = (p: string): boolean =>
     linkedDirs.some((d) => p === d || p.startsWith(d + path.sep));
 
-  // Angular's SourceFileCache extends Map but keeps what it actually tracked in
-  // `typeScriptFileCache` (.ts) and `referencedFiles` (templates/styles); the
-  // outer Map stays empty. Reading only `keys()` therefore watches NOTHING, so
-  // shared-mapping and exposed sources never invalidate and the dev server keeps
-  // serving stale bundles until it is restarted.
-  const federationSourceFiles = (cache: {
-    keys(): IterableIterator<string>;
-    typeScriptFileCache?: Map<string, unknown>;
-    referencedFiles?: readonly string[];
-  }): string[] =>
-    [
-      ...new Set<string>([
-        ...cache.keys(),
-        ...(cache.typeScriptFileCache?.keys() ?? []),
-        ...(cache.referencedFiles ?? []),
-      ]),
-    ].filter((file) => !file.includes("node_modules"));
-
+  // Watch what the federation compilation actually tracked — where the cache
+  // records it depends on the TS compilation path; see federationSourceFiles.
   const federationWatchedFiles = new Set<string>();
   const syncFederationWatcher = (): void => {
     if (!nfWatcher) return;
+    logger.verbose(
+      describeFederationCache(normalized.options.federationCache.bundlerCache),
+    );
     const files = federationSourceFiles(
       normalized.options.federationCache.bundlerCache,
     );
@@ -689,6 +695,7 @@ export async function* runBuilder(
           changeSignal,
         );
         if (trackResult.type === "completed" && !trackResult.result.cancelled) {
+          federationFresh = trackResult.result.success;
           yield { success: trackResult.result.success };
         }
         continue;
@@ -715,6 +722,22 @@ export async function* runBuilder(
       // rebuild on subsequent outputs, and only in watch mode.
       if (first || !watch) {
         first = false;
+        continue;
+      }
+
+      // An ordinary save reaches this loop twice: the file watcher usually wins
+      // the race (federationWatchedFiles covers most app sources), so the
+      // federation rebuild already ran, and this Angular output is the same
+      // save arriving second. With nothing new in the dirty buffer, rerunning
+      // would only re-link and rewrite identical federation outputs after
+      // another rebuildDelay — pass the Angular result through instead. The
+      // flag is consumed either way: it only vouches for the window since the
+      // last consumed Angular output.
+      const federationCoversThisOutput =
+        federationFresh && nfWatcher?.get().size === 0;
+      federationFresh = false;
+      if (federationCoversThisOutput) {
+        yield ngBuildStatus;
         continue;
       }
 

--- a/src/builders/build/builder.ts
+++ b/src/builders/build/builder.ts
@@ -425,6 +425,38 @@ export async function* runBuilder(
   const isUnderLinkedDir = (p: string): boolean =>
     linkedDirs.some((d) => p === d || p.startsWith(d + path.sep));
 
+  // Angular's SourceFileCache extends Map but keeps what it actually tracked in
+  // `typeScriptFileCache` (.ts) and `referencedFiles` (templates/styles); the
+  // outer Map stays empty. Reading only `keys()` therefore watches NOTHING, so
+  // shared-mapping and exposed sources never invalidate and the dev server keeps
+  // serving stale bundles until it is restarted.
+  const federationSourceFiles = (cache: {
+    keys(): IterableIterator<string>;
+    typeScriptFileCache?: Map<string, unknown>;
+    referencedFiles?: readonly string[];
+  }): string[] =>
+    [
+      ...new Set<string>([
+        ...cache.keys(),
+        ...(cache.typeScriptFileCache?.keys() ?? []),
+        ...(cache.referencedFiles ?? []),
+      ]),
+    ].filter((file) => !file.includes("node_modules"));
+
+  const federationWatchedFiles = new Set<string>();
+  const syncFederationWatcher = (): void => {
+    if (!nfWatcher) return;
+    const files = federationSourceFiles(
+      normalized.options.federationCache.bundlerCache,
+    );
+    for (const file of files) federationWatchedFiles.add(path.normalize(file));
+    syncNfFileWatcher(
+      nfWatcher,
+      { keys: () => files[Symbol.iterator]() },
+      linkedDirs,
+    );
+  };
+
   // watcherRef lets onChange reach the watcher without a const self-reference.
   const watcherRef: { current?: NfFileWatcher } = {};
   const nfWatcher: NfFileWatcher | undefined = watch
@@ -433,10 +465,16 @@ export async function* runBuilder(
         debounceMs: 100,
         onChange: (p) => {
           // Core stops filling the dirty buffer once onChange is set, so refill it
-          // here (Set.add stays idempotent if core is later fixed). Only wake the
-          // loop for linked edits; others ride the next Angular-driven rebuild.
+          // here (Set.add stays idempotent if core is later fixed). Wake the loop
+          // for edits the Angular-driven rebuild will NOT cover: linked dirs and
+          // the federation's own tracked sources, which are externals to the app
+          // build and so never reach Angular's rebuild iterator.
           watcherRef.current?.mutate((s) => s.add(p));
-          if (isUnderLinkedDir(p)) notifyChange();
+          if (
+            isUnderLinkedDir(p) ||
+            federationWatchedFiles.has(path.normalize(p))
+          )
+            notifyChange();
         },
       })
     : undefined;
@@ -474,13 +512,7 @@ export async function* runBuilder(
     await adapter.dispose("mapping-or-exposed").catch(() => undefined);
   }
 
-  if (nfWatcher) {
-    syncNfFileWatcher(
-      nfWatcher,
-      normalized.options.federationCache.bundlerCache,
-      linkedDirs,
-    );
-  }
+  syncFederationWatcher();
 
   const hasLocales = i18n?.locales && Object.keys(i18n.locales).length > 0;
   if (hasLocales && localeFilter) {
@@ -582,13 +614,7 @@ export async function* runBuilder(
         signal,
       );
 
-      if (nfWatcher) {
-        syncNfFileWatcher(
-          nfWatcher,
-          normalized.options.federationCache.bundlerCache,
-          linkedDirs,
-        );
-      }
+      syncFederationWatcher();
 
       if (signal?.aborted) {
         throw new AbortedError("[builder] After federation build.");

--- a/src/builders/remote/builder.ts
+++ b/src/builders/remote/builder.ts
@@ -27,6 +27,10 @@ import {
 
 import { createAngularBuildAdapter } from '../../tools/esbuild/angular-esbuild-adapter.js';
 import { checkForInvalidImports } from '../../utils/check-for-invalid-imports.js';
+import {
+  describeFederationCache,
+  federationSourceFiles
+} from '../../utils/federation-source-files.js';
 
 import type { NfRemoteBuilderSchema, NfRemoteInternalOptions } from './schema.js';
 import { resolveNgBuilderOptions } from './resolve-ng-options.js';
@@ -95,6 +99,11 @@ export async function* runRemoteBuilder(
   const start = process.hrtime();
   logger.measure(start, 'To load the federation config.');
 
+  // Which TS compilation path the build takes is decided by module-load order
+  // (see the note in build/builder.ts); pair this with the "SourceFileCache
+  // tracked files" line to see which path actually ran.
+  logger.verbose(`NG_BUILD_PARALLEL_TS=${process.env['NG_BUILD_PARALLEL_TS'] ?? '(unset)'}`);
+
   const externals = getExternals(normalized.config);
 
   // Realpath'd dirs of npm-linked shared packages (`[]` if none, making the
@@ -135,25 +144,12 @@ export async function* runRemoteBuilder(
 
   await copyAllAssets(assetEntries, absoluteBrowserOutput, context.workspaceRoot);
 
-  // Angular's SourceFileCache extends Map but keeps what it actually tracked in
-  // `typeScriptFileCache` (.ts) and `referencedFiles` (templates/styles); the
-  // outer Map stays empty. Reading only `keys()` therefore watches NOTHING, so
-  // shared-mapping and exposed sources never invalidate and the dev server keeps
-  // serving stale bundles until it is restarted.
+  // Watch what the federation compilation actually tracked — where the cache
+  // records it depends on the TS compilation path; see federationSourceFiles.
   const syncFederationWatcher = (): void => {
     if (!changeWatcher) return;
-    const cache = normalized.options.federationCache.bundlerCache as {
-      keys(): IterableIterator<string>;
-      typeScriptFileCache?: Map<string, unknown>;
-      referencedFiles?: readonly string[];
-    };
-    const files = [
-      ...new Set<string>([
-        ...cache.keys(),
-        ...(cache.typeScriptFileCache?.keys() ?? []),
-        ...(cache.referencedFiles ?? [])
-      ])
-    ].filter((file) => !file.includes('node_modules'));
+    logger.verbose(describeFederationCache(normalized.options.federationCache.bundlerCache));
+    const files = federationSourceFiles(normalized.options.federationCache.bundlerCache);
     syncNfFileWatcher(
       changeWatcher.watcher,
       { keys: () => files[Symbol.iterator]() },

--- a/src/builders/remote/builder.ts
+++ b/src/builders/remote/builder.ts
@@ -31,6 +31,7 @@ import {
   describeFederationCache,
   federationSourceFiles
 } from '../../utils/federation-source-files.js';
+import { createStaleWatchEventFilter } from '../../utils/stale-watch-event-filter.js';
 
 import type { NfRemoteBuilderSchema, NfRemoteInternalOptions } from './schema.js';
 import { resolveNgBuilderOptions } from './resolve-ng-options.js';
@@ -117,8 +118,12 @@ export async function* runRemoteBuilder(
     projectSourceRoot
   );
 
+  // staleEvents guards the wide watch list: macOS FSEvents replays events for
+  // recently-edited files without a content change, and unguarded that replay
+  // rebuilds forever (see stale-watch-event-filter.ts).
+  const staleEvents = createStaleWatchEventFilter();
   const changeWatcher = nfBuilderOptions.watch
-    ? createDebouncedChangeWatcher(nfBuilderOptions.rebuildDelay)
+    ? createDebouncedChangeWatcher(nfBuilderOptions.rebuildDelay, staleEvents.isRealChange)
     : undefined;
 
   if (changeWatcher) {
@@ -150,6 +155,7 @@ export async function* runRemoteBuilder(
     if (!changeWatcher) return;
     logger.verbose(describeFederationCache(normalized.options.federationCache.bundlerCache));
     const files = federationSourceFiles(normalized.options.federationCache.bundlerCache);
+    for (const file of files) staleEvents.seed(file);
     syncNfFileWatcher(
       changeWatcher.watcher,
       { keys: () => files[Symbol.iterator]() },

--- a/src/builders/remote/builder.ts
+++ b/src/builders/remote/builder.ts
@@ -135,13 +135,33 @@ export async function* runRemoteBuilder(
 
   await copyAllAssets(assetEntries, absoluteBrowserOutput, context.workspaceRoot);
 
-  if (changeWatcher) {
+  // Angular's SourceFileCache extends Map but keeps what it actually tracked in
+  // `typeScriptFileCache` (.ts) and `referencedFiles` (templates/styles); the
+  // outer Map stays empty. Reading only `keys()` therefore watches NOTHING, so
+  // shared-mapping and exposed sources never invalidate and the dev server keeps
+  // serving stale bundles until it is restarted.
+  const syncFederationWatcher = (): void => {
+    if (!changeWatcher) return;
+    const cache = normalized.options.federationCache.bundlerCache as {
+      keys(): IterableIterator<string>;
+      typeScriptFileCache?: Map<string, unknown>;
+      referencedFiles?: readonly string[];
+    };
+    const files = [
+      ...new Set<string>([
+        ...cache.keys(),
+        ...(cache.typeScriptFileCache?.keys() ?? []),
+        ...(cache.referencedFiles ?? [])
+      ])
+    ].filter((file) => !file.includes('node_modules'));
     syncNfFileWatcher(
       changeWatcher.watcher,
-      normalized.options.federationCache.bundlerCache,
+      { keys: () => files[Symbol.iterator]() },
       linkedDirs
     );
-  }
+  };
+
+  syncFederationWatcher();
 
   const rebuildQueue = new RebuildQueue();
 
@@ -197,11 +217,7 @@ export async function* runRemoteBuilder(
           // remain in pendingPaths and will drive the next iteration.
           for (const p of changedFiles) changeWatcher.pendingPaths.delete(p);
 
-          syncNfFileWatcher(
-            changeWatcher.watcher,
-            normalized.options.federationCache.bundlerCache,
-            linkedDirs
-          );
+          syncFederationWatcher();
 
           if (signal?.aborted) {
             throw new AbortedError('[remote-builder] After federation build.');

--- a/src/builders/remote/change-watcher.ts
+++ b/src/builders/remote/change-watcher.ts
@@ -8,7 +8,10 @@ export interface DebouncedChangeWatcher {
   dispose: () => void;
 }
 
-export function createDebouncedChangeWatcher(rebuildDelay: number): DebouncedChangeWatcher {
+export function createDebouncedChangeWatcher(
+  rebuildDelay: number,
+  isRealChange?: (path: string) => boolean
+): DebouncedChangeWatcher {
   const pendingPaths = new Set<string>();
 
   let notifyChange: () => void = () => {};
@@ -30,6 +33,10 @@ export function createDebouncedChangeWatcher(rebuildDelay: number): DebouncedCha
 
   const watcher = createNfWatcher({
     onChange: p => {
+      // Same-mtime replays (macOS FSEvents re-delivers events for recently
+      // edited files) must not enter pendingPaths: each entry drives a full
+      // rebuild cycle, so unfiltered replays rebuild forever.
+      if (isRealChange && !isRealChange(p)) return;
       pendingPaths.add(p);
       scheduleNotify();
     },

--- a/src/utils/federation-source-files.spec.ts
+++ b/src/utils/federation-source-files.spec.ts
@@ -1,0 +1,80 @@
+import { SourceFileCache } from '@angular/build/private';
+import type ts from 'typescript';
+
+import { describeFederationCache, federationSourceFiles } from './federation-source-files.js';
+
+function cacheWith(options: {
+  outer?: readonly string[];
+  typeScript?: readonly string[];
+  referenced?: readonly string[];
+}): SourceFileCache {
+  const cache = new SourceFileCache();
+  for (const file of options.outer ?? []) {
+    cache.set(file, {} as ts.SourceFile);
+  }
+  for (const file of options.typeScript ?? []) {
+    cache.typeScriptFileCache.set(file, '');
+  }
+  if (options.referenced) {
+    cache.referencedFiles = options.referenced;
+  }
+  return cache;
+}
+
+describe('federationSourceFiles', () => {
+  it('unions all three places the cache tracks files in', () => {
+    // outer Map: in-process TS path; typeScriptFileCache: emitted .ts output;
+    // referencedFiles: templates and styles (the only home they ever have).
+    const cache = cacheWith({
+      outer: ['/app/in-process.ts'],
+      typeScript: ['/app/emitted.ts'],
+      referenced: ['/app/cmp.html', '/app/cmp.scss'],
+    });
+
+    expect(federationSourceFiles(cache).sort()).toEqual([
+      '/app/cmp.html',
+      '/app/cmp.scss',
+      '/app/emitted.ts',
+      '/app/in-process.ts',
+    ]);
+  });
+
+  it('deduplicates files reported by more than one source', () => {
+    const cache = cacheWith({
+      outer: ['/app/shared.ts'],
+      typeScript: ['/app/shared.ts'],
+      referenced: ['/app/shared.ts'],
+    });
+
+    expect(federationSourceFiles(cache)).toEqual(['/app/shared.ts']);
+  });
+
+  it('drops node_modules entries from every source', () => {
+    const cache = cacheWith({
+      outer: ['/repo/node_modules/dep/index.ts'],
+      typeScript: ['/repo/node_modules/dep/emit.ts', '/repo/src/kept.ts'],
+      referenced: ['/repo/node_modules/dep/style.css'],
+    });
+
+    expect(federationSourceFiles(cache)).toEqual(['/repo/src/kept.ts']);
+  });
+
+  it('handles a cache that never set referencedFiles', () => {
+    const cache = cacheWith({ typeScript: ['/app/only.ts'] });
+
+    expect(federationSourceFiles(cache)).toEqual(['/app/only.ts']);
+  });
+});
+
+describe('describeFederationCache', () => {
+  it('reports the size of each tracking source', () => {
+    const cache = cacheWith({
+      typeScript: ['/app/a.ts', '/app/b.ts'],
+      referenced: ['/app/a.html'],
+    });
+
+    expect(describeFederationCache(cache)).toBe(
+      'SourceFileCache tracked files: outer=0, typeScript=2, referenced=1',
+    );
+  });
+});

--- a/src/utils/federation-source-files.ts
+++ b/src/utils/federation-source-files.ts
@@ -1,0 +1,40 @@
+import type { SourceFileCache } from '@angular/build/private';
+
+/**
+ * Files the federation compilation actually tracked, deduplicated and without
+ * node_modules — the watch list for federation-only rebuilds.
+ *
+ * Where Angular's `SourceFileCache` records a tracked file depends on the
+ * compilation mode. With in-process type checking (`NG_BUILD_PARALLEL_TS=0`)
+ * `augmentHostWithCaching` fills the outer Map with parsed `.ts` sources; on
+ * the default parallel path the type checker runs in a worker with its own
+ * cache and the outer Map stays empty. On both paths emitted `.ts` output
+ * lands in `typeScriptFileCache`, and templates/styles are listed only in
+ * `referencedFiles`. Reading only `keys()` therefore always missed templates
+ * and styles, and on the parallel path missed every tracked file — so
+ * shared-mapping and exposed sources never invalidated and the dev server
+ * kept serving stale bundles until it was restarted.
+ */
+export function federationSourceFiles(cache: SourceFileCache): string[] {
+  return [
+    ...new Set<string>([
+      ...cache.keys(),
+      ...cache.typeScriptFileCache.keys(),
+      ...(cache.referencedFiles ?? []),
+    ]),
+  ].filter((file) => !file.includes('node_modules'));
+}
+
+/**
+ * One-line fingerprint of where the cache tracked its files, for diagnosing
+ * which compilation path a dev server is on: a populated outer Map means
+ * in-process type checking (`NG_BUILD_PARALLEL_TS=0`); an empty outer Map
+ * alongside a populated `typeScriptFileCache` means the parallel-TS path.
+ */
+export function describeFederationCache(cache: SourceFileCache): string {
+  return (
+    `SourceFileCache tracked files: outer=${cache.size}, ` +
+    `typeScript=${cache.typeScriptFileCache.size}, ` +
+    `referenced=${cache.referencedFiles?.length ?? 0}`
+  );
+}

--- a/src/utils/stale-watch-event-filter.spec.ts
+++ b/src/utils/stale-watch-event-filter.spec.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createStaleWatchEventFilter } from './stale-watch-event-filter.js';
+
+describe('createStaleWatchEventFilter', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nf-stale-filter-'));
+    file = path.join(dir, 'source.ts');
+    fs.writeFileSync(file, 'export const a = 1;');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('drops a replayed event for a seeded, unmodified file', () => {
+    const filter = createStaleWatchEventFilter();
+    filter.seed(file);
+
+    expect(filter.isRealChange(file)).toBe(false);
+    expect(filter.isRealChange(file)).toBe(false);
+  });
+
+  it('passes an event through when the mtime advanced, then drops its replay', () => {
+    const filter = createStaleWatchEventFilter();
+    filter.seed(file);
+
+    const later = new Date(Date.now() + 5_000);
+    fs.utimesSync(file, later, later);
+
+    expect(filter.isRealChange(file)).toBe(true);
+    expect(filter.isRealChange(file)).toBe(false);
+  });
+
+  it('treats the first event for an unseeded file as real and its replay as stale', () => {
+    const filter = createStaleWatchEventFilter();
+
+    expect(filter.isRealChange(file)).toBe(true);
+    expect(filter.isRealChange(file)).toBe(false);
+  });
+
+  it('treats a deleted file as a real change', () => {
+    const filter = createStaleWatchEventFilter();
+    filter.seed(file);
+    fs.rmSync(file);
+
+    expect(filter.isRealChange(file)).toBe(true);
+  });
+});

--- a/src/utils/stale-watch-event-filter.ts
+++ b/src/utils/stale-watch-event-filter.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface StaleWatchEventFilter {
+  /** Record the current mtime when a file first enters the watch list. */
+  seed(file: string): void;
+  /** True when the event reflects an actual content change (or a deletion). */
+  isRealChange(file: string): boolean;
+}
+
+/**
+ * Drops file-watch events that do not correspond to a content change.
+ *
+ * On macOS, FSEvents re-delivers "changed" events for recently modified files
+ * on a ~30s cadence even when nothing touched them again (mtime and ctime
+ * stay put). Once the watch list covers every federation-tracked source
+ * (federationSourceFiles), a single recently-edited file otherwise wakes the
+ * rebuild loop forever — rebuild, replayed event, rebuild — pinning a core
+ * until the dev server is stopped.
+ *
+ * Comparing the file's mtime against the last value seen lets every real
+ * save through (its mtime advances) while replays compare equal and are
+ * dropped before they reach the dirty buffer. A failed stat counts as a real
+ * change: a deleted or renamed-away file must trigger a rebuild.
+ */
+export function createStaleWatchEventFilter(): StaleWatchEventFilter {
+  const mtimes = new Map<string, number>();
+
+  const mtimeOf = (file: string): number | null => {
+    try {
+      return fs.statSync(file).mtimeMs;
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    seed(file: string): void {
+      const key = path.normalize(file);
+      if (mtimes.has(key)) return;
+      const mtime = mtimeOf(key);
+      if (mtime !== null) mtimes.set(key, mtime);
+    },
+    isRealChange(file: string): boolean {
+      const key = path.normalize(file);
+      const mtime = mtimeOf(key);
+      if (mtime === null) {
+        mtimes.delete(key);
+        return true;
+      }
+      if (mtimes.get(key) === mtime) {
+        return false;
+      }
+      mtimes.set(key, mtime);
+      return true;
+    },
+  };
+}


### PR DESCRIPTION
Fixes #94.

## Problem

While the dev server runs, edits to shared-mapping libraries and exposed sources never reach the emitted federation bundles. The dev server keeps serving stale code until it is restarted; a hard browser reload does not help.

## Root cause

`syncNfFileWatcher` decides what to watch from the bundler cache:

```ts
const files = [...bundlerCache.keys()].filter((k) => !k.includes('node_modules'));
```

`bundlerCache` is Angular's `SourceFileCache`. That class extends `Map`, but where a tracked file is recorded depends on the compilation mode:

- On the **parallel-TS path** the type checker runs in a worker that builds its own `SourceFileCache` (`parallel-compilation.ts` never receives the outer one), so the outer Map stays empty.
- With **in-process type checking** (`NG_BUILD_PARALLEL_TS=0`, applied before anything imports `@angular/build`) `augmentHostWithCaching` does populate the outer Map with parsed `.ts` sources.
- On **both paths**, emitted `.ts` output lands in `typeScriptFileCache`, and templates/styles are listed only in `referencedFiles` (`SourceFileCache.invalidate()` itself consults `referencedFiles` via `extraWatchFiles`).

So reading only `keys()` always misses templates and styles, and on the parallel path misses everything.

**Which path was the instrumented run on?** The parallel one — confirmed with the diagnostics this PR now logs at verbose level (`NG_BUILD_PARALLEL_TS` at builder start plus the observed cache shape after each watcher sync). On the Nx workspace below the dev server prints:

```
NG_BUILD_PARALLEL_TS=0
SourceFileCache tracked files: outer=0, typeScript=182, referenced=1743
```

`setup-builder-env-variables.ts` did set `NG_BUILD_PARALLEL_TS=0`, but `useParallelTs` is a module-level const in `@angular/build`, and under Nx something imports `@angular/build` before the builder module does — so the env assignment comes too late and the parallel path runs anyway. That makes part 1 load-bearing for Nx users regardless of the intended default, and it is a second bug worth filing separately (the env var silently not taking effect). `useParallelTs` is not re-exported through `@angular/build/private`, so the effective path cannot be read directly; the env value + cache shape pair in the logs is the reliable signal.

There is a second gap on the same path (load-bearing on either compilation path): the rebuild loop is only woken for npm-linked dirs (`if (isUnderLinkedDir(p)) notifyChange()`). Shared mappings and exposes are *externals* for the app build, so Angular's own rebuild iterator never emits for them — the "ride the next Angular-driven rebuild" fallback never arrives.

## Fix

1. Feed `syncNfFileWatcher` a key view over the union of the outer `keys()`, `typeScriptFileCache` and `referencedFiles` — covers both compilation paths. The helper lives in `src/utils/federation-source-files.ts`, is typed against `SourceFileCache` (a future Angular rename now breaks the build instead of silently regressing to no watching) and is covered by a spec.
2. Wake the rebuild loop for those tracked sources as well, not only for linked dirs.
3. Skip the Angular-driven federation rebuild when a watcher-driven rebuild already completed since the last consumed Angular output and the dirty buffer is empty. Without this, an ordinary save pays twice: the watcher wakes the loop first and rebuilds, then Angular's output for the same save triggers a second full pass — another `rebuildDelay` plus a re-link that rewrites identical outputs.
4. Filter watch events through an mtime check before they reach the dirty buffer (`src/utils/stale-watch-event-filter.ts`, with spec — see below for why this is required, not optional, once the watch list is this wide).

Points 1, 2 and 4 apply to both `build/builder.ts` and `remote/builder.ts`; the remote builder has no Angular-output race, so point 3 only applies to `build`.

## Found while verifying: FSEvents replay turns the wide watch list into an infinite rebuild loop

Live-testing this branch on the workspace below surfaced a failure mode the original submission missed. On macOS, FSEvents re-delivers "changed" events for recently modified files on a ~30 s cadence even when nothing touched them again — mtime and ctime stay put. Instrumenting the raw `fs.watch` callbacks showed the pattern clearly:

```
21:35:38.896Z change libs/platform/logging/src/index.ts
21:36:09.007Z change libs/platform/logging/src/index.ts   (+30.1 s, no edit)
21:36:39.121Z change libs/platform/logging/src/index.ts   (+30.1 s, no edit)
```

With every federation-tracked source watched (~1,900 files here), one recently-edited file is enough: the replay wakes the loop, the rebuild resyncs the watcher, the next replay fires again — federation rebuilds run forever and pin a core until the dev server is stopped. The original code never hit this because it effectively watched nothing.

The filter drops any event whose mtime matches the last value seen for that path; a real save advances mtime and passes, and a failed stat (deletion) passes. Watch-list entries are seeded with their current mtime at sync time, so a replay never triggers even one spurious rebuild.

## Verification

Original round, measured on a real Nx + Angular 22.0.8 workspace (host + 3 remotes) by writing a marker into a source file while the dev server is running, then checking whether it reaches the emitted bundle:

| case | before | after |
| --- | --- | --- |
| shared-mapping `.ts` edit | stale — bundle unchanged, marker absent | marker present |
| exposed screen `.html` edit | stale — rebuild runs, chunk never contains the marker | marker present in the exposed chunk |

The `.html` case is the variant described in the issue comment (triggered through `exposes` rather than `sharedMappings`). Both go through the same `mapping-or-exposed` context, so a single fix closes both.

Review round, re-verified end-to-end with the built artifact (all four changes combined) dropped into the consuming workspace's `node_modules`:

- A shared-mapping `.ts` save produced exactly **one** federation rebuild: the marker reached the emitted `_apex_platform_logging.js` and the rewritten `remoteEntry.json` **one second** after the save, and was served by the dev middleware. No second cycle followed the same save's Angular output (point 3 above at work).
- With the save leaving the file "recently modified" — the exact FSEvents replay trigger — an 80 s watch window recorded **zero** further rebuild cycles; before the filter, the same setup rebuilt every ~30 s indefinitely.
- The diagnostics print the path fingerprint quoted above at builder start.

`npm run typecheck`, `npm run lint` (0 errors; warning count identical to the unmodified baseline) and `vitest run` (16 files / 111 tests) all pass.
