### PR TITLE
fix: Prevented double -v4 substitution in the update-v4 schematic (21.x.x)

### DIFF
--- a/src/schematics/update-v4/schematic.spec.ts
+++ b/src/schematics/update-v4/schematic.spec.ts
@@ -1,0 +1,75 @@
+import { HostTree, type SchematicContext } from '@angular-devkit/schematics';
+
+import updateV4 from './schematic.js';
+
+const V4_CONFIG_IMPORT =
+  "import { withNativeFederation, shareAll } from '@angular-architects/native-federation-v4/config';";
+
+describe('update-v4 schematic', () => {
+  let tree: HostTree;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    tree = new HostTree();
+    tree.create(
+      'angular.json',
+      JSON.stringify({
+        projects: {
+          shell: { root: '', sourceRoot: 'src', architect: {} },
+        },
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runSchematic(): Promise<void> {
+    await updateV4({ project: 'shell' })(tree, {} as SchematicContext);
+  }
+
+  it('migrates a CJS federation.config.js to ESM with a single -v4 suffix', async () => {
+    tree.create(
+      'federation.config.js',
+      [
+        "const { withNativeFederation, shareAll } = require('@angular-architects/native-federation/config');",
+        '',
+        'module.exports = withNativeFederation({',
+        "  name: 'shell',",
+        '  shared: {',
+        '    ...shareAll({ singleton: true }),',
+        '  },',
+        '});',
+        '',
+      ].join('\n')
+    );
+
+    await runSchematic();
+
+    expect(tree.exists('federation.config.mjs')).toBe(true);
+    const content = tree.readText('federation.config.mjs');
+    expect(content).toContain(V4_CONFIG_IMPORT);
+    expect(content).not.toContain('native-federation-v4-v4');
+    expect(content).toContain('export default withNativeFederation({');
+  });
+
+  it('leaves an already-updated v4 require path untouched', async () => {
+    tree.create(
+      'federation.config.js',
+      [
+        "const { withNativeFederation, shareAll } = require('@angular-architects/native-federation-v4/config');",
+        '',
+        'module.exports = withNativeFederation({});',
+        '',
+      ].join('\n')
+    );
+
+    await runSchematic();
+
+    expect(tree.exists('federation.config.mjs')).toBe(true);
+    const content = tree.readText('federation.config.mjs');
+    expect(content).toContain(V4_CONFIG_IMPORT);
+    expect(content).not.toContain('native-federation-v4-v4');
+  });
+});

--- a/src/schematics/update-v4/schematic.ts
+++ b/src/schematics/update-v4/schematic.ts
@@ -86,7 +86,10 @@ function migrateFederationConfigs(tree: Tree, workspace: any, options: UpdateV4S
     const requireRegex = /const\s+(\{[^}]+\})\s*=\s*require\(\s*['"]([^'"]+)['"]\s*\)\s*;?/g;
     const imports: string[] = [];
     content = content.replace(requireRegex, (_match, bindings: string, modulePath: string) => {
-      const updatedPath = modulePath.replace(V3_PACKAGE, V4_PACKAGE);
+      const updatedPath = modulePath.replace(
+        new RegExp(escapeRegExp(V3_PACKAGE) + '(?!-v4)'),
+        V4_PACKAGE
+      );
       imports.push(`import ${bindings} from '${updatedPath}';`);
       return ''; // Remove the require line; import will be prepended
     });
@@ -105,7 +108,7 @@ function migrateFederationConfigs(tree: Tree, workspace: any, options: UpdateV4S
       new RegExp(escapeRegExp(V3_PACKAGE + '/config'), 'g'),
       V4_PACKAGE + '/config'
     );
-    content = content.replace(new RegExp(escapeRegExp(V3_PACKAGE) + '(?!/)', 'g'), V4_PACKAGE);
+    content = content.replace(new RegExp(escapeRegExp(V3_PACKAGE) + '(?!/|-v4)', 'g'), V4_PACKAGE);
 
     if (content !== originalContent) {
       tree.delete(configPath);


### PR DESCRIPTION
Fixes #99

## Problem

`ng g @angular-architects/native-federation-v4:update-v4 <project>` rewrites the federation config import to `@angular-architects/native-federation-v4-v4/config` (doubled `-v4`), which does not resolve, so the build fails until corrected by hand.

## Cause

Two substitution passes in `migrateFederationConfigs` compound:

1. The require-to-import rewrite already updates the module path to `@angular-architects/native-federation-v4/config`.
2. The bare-package replacement then matches the v3 prefix inside that already-substituted specifier, because its `(?!/)` lookahead only guards against a following `/` and the next character here is `-`. It appends a second `-v4`.

Note: reordering the replacements (as suggested as an alternative in the issue) would not help, since the first substitution happens in the require-to-import rewrite before either content-level replacement runs.

## Fix

Guard both substitutions against an already-substituted prefix:

- The require-path rewrite now uses a `(?!-v4)` lookahead.
- The bare-package replacement lookahead is widened from `(?!/)` to `(?!/|-v4)`.

The conservative semantics of the bare replacement (skip subpaths other than `/config`) are unchanged.

## Tests

Added `src/schematics/update-v4/schematic.spec.ts` covering the reported repro (CJS config on v3) and idempotence (a require path already on v4 stays single `-v4`). Both failed before the fix, reproducing `-v4-v4/config` and `-v4-v4-v4/config` respectively, and pass after. Full suite, typecheck, and lint are clean.
