### PR TITLE
fix: Declared mrmime as a runtime dependency (21.x.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "@angular-devkit/core": "^21.2.0",
     "@angular-devkit/schematics": "^21.2.0",
     "@angular/build": "^21.2.0",
-    "@chialab/esbuild-plugin-commonjs": "^0.19.0"
+    "@chialab/esbuild-plugin-commonjs": "^0.19.0",
+    "mrmime": "^2.0.1"
   },
   "repository": {
     "type": "git",
@@ -86,7 +87,6 @@
     "jiti": "^2.6.0",
     "json5": "^2.2.3",
     "knip": "^6.17.1",
-    "mrmime": "^2.0.1",
     "tslib": "^2.3.0",
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.46.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@softarc/native-federation-orchestrator':
         specifier: ^4.5.2
         version: 4.5.2
+      mrmime:
+        specifier: ^2.0.1
+        version: 2.0.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -69,9 +72,6 @@ importers:
       knip:
         specifier: ^6.17.1
         version: 6.26.0
-      mrmime:
-        specifier: ^2.0.1
-        version: 2.0.1
       tslib:
         specifier: ^2.3.0
         version: 2.8.1


### PR DESCRIPTION
Fixes #100

`src/builders/build/builder.ts` and `src/plugin/index.ts` import `mrmime` at runtime, but the package only declared it in `devDependencies`, which `post-build.mjs` strips from the published manifest. The import only resolved while another installed package happened to hoist `mrmime` (typically the v3 mainline package left in place during migration), and `ng build` fails with `Cannot find package 'mrmime'` once that is uninstalled.

This moves `mrmime` to `dependencies`, matching the mainline package. Verified locally: `pnpm build` now emits `dist/package.json` with `mrmime` under `dependencies`, and typecheck, lint, and tests pass.

Note on scope: `esbuild` and `json5` are also imported at runtime without being declared (as are `@schematics/angular` and `@nx/devkit` in the schematics and generator entry points). Those are deliberately not added here because they are highly likely to be already installed through Angular's own dependencies (`@angular/build`, `@angular-devkit/*`), unlike `mrmime`, which nothing else in an Angular workspace provides.
