### PR TITLE
fix: Declared mrmime as a runtime dependency (20.3.x)

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -25,7 +25,8 @@
     "@angular-devkit/core": "~20.3.1",
     "@angular-devkit/schematics": "~20.3.1",
     "@angular/build": "~20.3.1",
-    "@chialab/esbuild-plugin-commonjs": "^0.19.0"
+    "@chialab/esbuild-plugin-commonjs": "^0.19.0",
+    "mrmime": "^2.0.1"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       '@softarc/native-federation-orchestrator':
         specifier: ^4.2.2
         version: 4.2.2
+      mrmime:
+        specifier: ^2.0.1
+        version: 2.0.1
 
 packages:
 


### PR DESCRIPTION
Fixes #100 for the 20.x line (same fix as #104)

`packages/angular/src/builders/build/builder.ts` and `packages/angular/src/plugin/index.ts` import `mrmime` at runtime, but the hand-curated `dependencies` list in `packages/angular/package.json` never included it (only the workspace root manifest did, which is why local development never noticed). The import only resolved while another installed package happened to hoist `mrmime` (typically the v3 mainline package left in place during migration), and `ng build` fails with `Cannot find package 'mrmime'` once that is uninstalled.

This adds `mrmime` to the publishable manifest's `dependencies`, matching the mainline package. Verified locally: `nx build angular-adapter` now emits `packages/angular/dist/package.json` with `mrmime` under `dependencies`, and the test target passes.

Note on scope: `esbuild` and `json5` are also imported at runtime without being declared (as are `@schematics/angular` and `@nx/devkit` in the schematics and generator entry points). Those are deliberately not added here because they are highly likely to be already installed through Angular's own dependencies (`@angular/build`, `@angular-devkit/*`), unlike `mrmime`, which nothing else in an Angular workspace provides.
