### PR TITLE
chore: Temporarily re-added force killsignal

### DIFF
--- a/src/builders/build/builder.ts
+++ b/src/builders/build/builder.ts
@@ -612,6 +612,7 @@ export async function* runBuilder(
       if (isLocalDevelopment) {
         federationBuildNotifier.broadcastBuildCompletion();
       }
+
       return { success: true };
     } catch (error) {
       if (error instanceof AbortedError) {
@@ -714,6 +715,9 @@ export async function* runBuilder(
     if (isLocalDevelopment) {
       federationBuildNotifier.stopEventServer();
     }
+
+    // TODO: fix retry issue from #106
+    setTimeout(() => process.exit(ngBuildStatus.success ? 0 : 1), 500).unref();
   }
 
   yield ngBuildStatus;


### PR DESCRIPTION
Closes #95 

This pull request introduces a minor update to the `runBuilder` function in `src/builders/build/builder.ts` to improve process exit handling and includes a note to address a known retry issue.

Process exit handling:

* Added a delayed call to `process.exit` after the build completes, ensuring the process exits with the correct status code after a short timeout. This helps address issues with process termination reliability.

Maintenance and TODOs:

* Added a TODO comment referencing issue #106 to highlight a retry issue that needs to be fixed in the future.