### PR TITLE
fix(bundler): pass the configured tsconfig to esbuild BuildOptions

### DIFF
--- a/src/builders/build/schema.json
+++ b/src/builders/build/schema.json
@@ -61,7 +61,7 @@
     },
     "tsConfig": {
       "type": "string",
-      "description": "A specific tsconfig file for the nf remotes and exposed modules."
+      "description": "A specific tsconfig file for the nf remotes and exposed modules. It also drives esbuild's module resolution, so it must declare or extend the workspace baseUrl/paths."
     },
     "cacheExternalArtifacts": {
       "type": "boolean",

--- a/src/builders/remote/schema.json
+++ b/src/builders/remote/schema.json
@@ -8,7 +8,7 @@
   "properties": {
     "tsConfig": {
       "type": "string",
-      "description": "Path to the tsconfig used to compile the exposed modules and shared mappings."
+      "description": "Path to the tsconfig used to compile the exposed modules and shared mappings. It also drives esbuild's module resolution, so it must declare or extend the workspace baseUrl/paths."
     },
     "dev": {
       "type": "boolean",

--- a/src/tools/esbuild/angular-bundler.spec.ts
+++ b/src/tools/esbuild/angular-bundler.spec.ts
@@ -1,0 +1,100 @@
+import * as path from 'path';
+import * as esbuild from 'esbuild';
+import type { CompilerPluginOptions } from '@angular/build/private';
+
+import { createAngularEsbuildContext } from './angular-bundler.js';
+import { createAwaitableCompilerPlugin } from './create-awaitable-compiler-plugin.js';
+import { updateFederationTsConfig } from './create-federation-tsconfig.js';
+import type { NormalizedContextOptions } from '../../utils/normalize-context-options.js';
+
+vi.mock('esbuild', () => ({ context: vi.fn().mockResolvedValue({ rebuild: vi.fn() }) }));
+
+vi.mock('@angular/build/private', () => ({
+  getSupportedBrowsers: () => ['chrome 130'],
+  transformSupportedBrowsersToTargets: () => ['chrome130'],
+  generateSearchDirectories: async () => [],
+  findTailwindConfiguration: () => undefined,
+  loadPostcssConfiguration: async () => undefined,
+}));
+
+vi.mock('./create-awaitable-compiler-plugin.js', () => ({
+  createAwaitableCompilerPlugin: vi
+    .fn()
+    .mockReturnValue([{ name: 'angular-compiler', setup: vi.fn() }, Promise.resolve()]),
+}));
+
+vi.mock('./create-federation-tsconfig.js', () => ({ updateFederationTsConfig: vi.fn() }));
+
+vi.mock('@chialab/esbuild-plugin-commonjs', () => ({
+  default: () => ({ name: 'commonjs', setup: vi.fn() }),
+}));
+
+const workspaceRoot = path.join(path.sep, 'ws');
+
+function makeOptions(overrides: Partial<NormalizedContextOptions> = {}) {
+  return {
+    builderOptions: { optimization: false, sourceMap: false },
+    context: {
+      workspaceRoot,
+      target: { project: 'example' },
+      logger: { warn: vi.fn() },
+      getProjectMetadata: async () => ({ root: 'apps/example' }),
+    },
+    entryPoints: [{ fileName: 'apps/example/src/main.ts', outName: 'main.js' }],
+    external: [],
+    outdir: '/out',
+    tsConfigPath: 'apps/example/tsconfig.app.json',
+    mappedPaths: {},
+    cache: { bundlerCache: { loadResultCache: {} }, cachePath: '/cache' },
+    dev: false,
+    isMappingOrExposed: true,
+    hash: false,
+    optimizedMappings: false,
+    ...overrides,
+  } as unknown as NormalizedContextOptions;
+}
+
+function lastBuildOptions(): esbuild.BuildOptions {
+  return vi.mocked(esbuild.context).mock.calls.at(-1)![0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(esbuild.context).mockResolvedValue({ rebuild: vi.fn() } as never);
+});
+
+describe('createAngularEsbuildContext', () => {
+  it('throws when no tsconfig is configured', async () => {
+    const options = makeOptions({ tsConfigPath: undefined });
+
+    await expect(createAngularEsbuildContext(options)).rejects.toThrow('tsConfigPath is required');
+  });
+
+  // #98
+  it('passes the normalized tsconfig path to esbuild, not only to the plugin', async () => {
+    await createAngularEsbuildContext(makeOptions());
+
+    const expected = path.join(workspaceRoot, 'apps/example/tsconfig.app.json');
+
+    expect(lastBuildOptions().tsconfig).toBe(expected);
+
+    const [pluginOptions] = vi.mocked(createAwaitableCompilerPlugin).mock.calls[0] as [
+      CompilerPluginOptions,
+    ];
+    expect(pluginOptions.tsconfig).toBe(expected);
+  });
+
+  it('joins the workspace root once when mappings are optimized', async () => {
+    await createAngularEsbuildContext(makeOptions({ optimizedMappings: true }));
+
+    // updateFederationTsConfig joins the workspace root itself
+    expect(updateFederationTsConfig).toHaveBeenCalledWith(
+      workspaceRoot,
+      'apps/example/tsconfig.app.json',
+      expect.anything()
+    );
+    expect(lastBuildOptions().tsconfig).toBe(
+      path.join(workspaceRoot, 'apps/example/tsconfig.app.json')
+    );
+  });
+});

--- a/src/tools/esbuild/angular-bundler.ts
+++ b/src/tools/esbuild/angular-bundler.ts
@@ -167,6 +167,9 @@ export async function createAngularEsbuildContext(options: NormalizedContextOpti
     },
     ...(builderOptions.loader ? { loader: builderOptions.loader } : {}),
     resolveExtensions: ['.ts', '.tsx', '.mjs', '.js', '.cjs'],
+    // The compiler plugin only hooks onLoad; esbuild resolves bare specifiers itself
+    // and would otherwise only honour paths from an auto-discovered `tsconfig.json`.
+    tsconfig: tsConfigPath,
   };
 
   const ctx = await esbuild.context(config);


### PR DESCRIPTION
Fixes #98.

## Problem

`createAngularEsbuildContext` normalizes the configured tsconfig and hands it to the Angular compiler plugin, but never puts it on the `esbuild.BuildOptions` passed to `esbuild.context`.

The compiler plugin only registers `onLoad` hooks — it has no `onResolve` — so every bare specifier in the emitted code is resolved by esbuild itself. Without `tsconfig` in `BuildOptions`, esbuild honours `baseUrl`/`paths` only from a file it auto-discovers named exactly `tsconfig.json`. That misses the standard Angular/Nx layout (`tsconfig.app.json` / `tsconfig.lib.json`, mappings in `tsconfig.base.json`) and the build fails with `Could not resolve "…"`.

## Fix

Pass the already-normalized absolute path (`angular-bundler.ts`, resolved a few lines above) to esbuild as well:

```ts
resolveExtensions: ['.ts', '.tsx', '.mjs', '.js', '.cjs'],
tsconfig: tsConfigPath,
```

This is exactly what Angular's own application builder does — `@angular/build/src/builders/application/options.js` computes `path.join(workspaceRoot, options.tsConfig)` and `application-code-bundle.js` puts it on the shared esbuild options. The federation artefact build was the odd one out; it now agrees with the app build.

Not applied to `node-modules-bundler.ts`: that context only bundles node_modules and its `resolveExtensions` excludes `.ts`, so a tsconfig there could only change dependency resolution for the worse.

## Alternatives considered

- **`tsconfigRaw` with `baseUrl`/`paths`** — resolves correctly, but requires walking the `extends` chain by hand, drops the other compilerOptions esbuild reads, and (measured) disables nested `tsconfig.json` discovery exactly like `tsconfig` does. Strictly worse.
- **Custom `onResolve` plugin using `ts.resolveModuleName`** — the only option that preserves nested discovery, but it reimplements TS + esbuild resolution semantics with its own cache and perf surface, and diverges from the app build.
- **Passing core's root tsconfig instead** (`findRootTsConfigJson()`, i.e. `tsconfig.base.json` or the root `tsconfig.json`) — tempting, since that is where the shared-mapping aliases actually come from, and it would be immune to a bare federation tsconfig. Rejected: it would put esbuild and the TypeScript program on different configs — the very inconsistency this PR removes — and drop the project-level compiler options esbuild reads. In the default case the two coincide anyway, because the project tsconfig extends the base one.

## Behaviour changes

Overriding esbuild's tsconfig discovery is not free. All three cases below are pre-existing behaviour in `ng build` (which already passes a tsconfig), so any workspace they affect is already broken outside federation — but they belong in the release notes.

Measured against esbuild 0.28.1:

1. **A dedicated federation tsconfig must extend the workspace config.** If `tsConfig` points at a purpose-built file that doesn't inherit `baseUrl`/`paths`, the root `tsconfig.json` that used to be auto-discovered is now ignored:
   ```
   root tsconfig.json has paths, no tsconfig option        : OK
   root tsconfig.json has paths, tsconfig=federation (bare): FAIL -> Could not resolve "example/feature"
   root tsconfig.json has paths, tsconfig=tsconfig.app.json: OK
   ```
   Today's default is unaffected: nothing in the current schematics or generators emits `tsConfig`, so it falls back to the Angular target's tsconfig (`builder.ts`), normally `tsconfig.app.json`, which extends the base config.

   Worth noting for the installed base: `1bfc4a2` (v21.1.x) had the init schematic generate `<projectRoot>/tsconfig.federation.json` and wire it as `tsConfig`; it was dropped again in `858f94a`. Workspaces scaffolded in that window still carry the file in `angular.json`. It was generated with `"extends": "<relToRoot>/tsconfig.json"`, so it inherits the root mappings and is fine (verified). It only breaks if that `extends` target doesn't carry them — e.g. an Nx layout keeping mappings in `tsconfig.base.json`. Note that esbuild ignores an unresolvable `extends` silently and then fails with the same `Could not resolve` message as this issue, which is a confusing symptom to land on right after upgrading.

   The requirement is now documented in both builder schemas. It is also what core already assumes: shared mappings are read from a third file entirely — `with-native-federation.js` calls `getRawMappedPaths(findRootTsConfigJson(), …)`, which prefers `tsconfig.base.json` and falls back to the root `tsconfig.json`, independent of both the nf and the Angular tsconfig. So a federation tsconfig that doesn't extend that root config can declare aliases core maps but esbuild cannot resolve. Mapped entry points themselves are unaffected (core passes them as absolute paths, and `external` wins over `paths`); the exposure is plain alias imports inside exposed or shared code that aren't externalized.

2. **Nested `tsconfig.json` `paths` are no longer discovered.** Only bites a library that *redefines* `paths` with mappings the app config never inherits. The ordinary Nx shape — lib `tsconfig.json` extending `tsconfig.base.json` without its own `paths` — is unaffected (verified both ways).

3. **`baseUrl` can shadow a node_modules package.** Requires a top-level directory named exactly like a dependency *and* a resolvable index inside it; without an index, esbuild falls back to the real package. This is TypeScript's own precedence.

Explicitly verified as **not** affected:

- **`external` still wins over a `paths` mapping** — the federation-critical one, since shared mappings are tsconfig path aliases. Had `paths` started winning, shared libs would have been silently inlined into remotes instead of loading from the import map. Tested with a mapping and an `external` entry for the same specifier: stays external, with and without the option.
- **Angular-compiled files** — the plugin serves program files pre-transformed; only its fallback path (a `.ts` file outside the program needing no Angular compilation, already a warning case) hands raw TS to esbuild, which now reads compiler options from the configured tsconfig instead of an arbitrary discovered one.

## Tests

New `src/tools/esbuild/angular-bundler.spec.ts`:

- the normalized path reaches both `esbuild.context` and the compiler plugin (regression test for this issue — verified it fails with the line removed);
- with `optimizedMappings`, `updateFederationTsConfig` still receives the workspace-*relative* path, since it joins the root itself (double-joining is the easy bug here);
- the missing-tsconfig throw.

Full suite 151/151, typecheck clean, lint 0 errors.

Thanks to @oparicio-mmc for the precise diagnosis and repro shape in #98.
