### PR TITLE
feat(config): pass mappingsFromWorkspace through the config API

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,42 @@ The builder exposes:
 
 Unlike the core `fromPackageJson`, this adapter's version pre-seeds the Angular skip list (`NG_SKIP_LIST`) — the same list `shareAll` uses — so Angular-internal and localization packages are skipped for you out of the box.
 
+### Configuring Shared Mappings
+
+Workspace libraries mapped in `compilerOptions.paths` are shared via `sharedMappings`. Besides plain strings, an entry can pair a list of patterns with a config, so a mapped path carries the same metadata as a shared npm package:
+
+```js
+export default withNativeFederation({
+  sharedMappings: ["@my-org/auth-lib", [["@my-org/ui/*"], { singleton: false }]],
+});
+```
+
+Entries are matched as patterns rather than exact keys, so `'@my-org/*'` selects every mapped path under that scope. When several entries match the same mapped path, the first one wins — put the specific entries before the general ones.
+
+For more than a couple of entries, `mappingsFromWorkspace` builds that array for you:
+
+```js
+import {
+  withNativeFederation,
+  mappingsFromWorkspace,
+} from "@angular-architects/native-federation/config";
+
+export default withNativeFederation({
+  sharedMappings: mappingsFromWorkspace({ singleton: true, strictVersion: true })
+    .filter(["@my-org/ui/*", "@my-org/auth-lib"])
+    .patch(["@my-org/ui/*"], { singleton: false })
+    .get(),
+});
+```
+
+| Method                  | Purpose                                                                     |
+| ----------------------- | --------------------------------------------------------------------------- |
+| `.filter(patterns)`     | Narrow the selection. Omit it to select every mapped path.                   |
+| `.patch(patterns, cfg)` | Merge a partial config into the matching mappings; never widens the selection. |
+| `.get()`                | Resolve the builder into the `sharedMappings` array.                        |
+
+Requires `@softarc/native-federation` ≥ `4.4.0`. See the [core README](https://github.com/native-federation/native-federation-core#configuring-shared-mappings) for which `ExternalConfig` properties a mapping honours, how `includeSecondaries: { keepAll: true, resolveGlob: true }` keeps mappings nothing imports, and why only barrel imports can be shared as a mapped path.
+
 ### SSR and Hydration
 
 We support Angular's SSR and (Incremental) Hydration. Please find [more information here](https://www.angulararchitects.io/blog/ssr-and-hydration-with-native-federation-for-angular/).

--- a/src/builders/build/builder.ts
+++ b/src/builders/build/builder.ts
@@ -293,10 +293,8 @@ export async function* runBuilder(
     createFederationCache(cachePath, new SourceFileCache(cachePath)),
   );
 
-  checkForInvalidImports(
-    Object.values(normalized.config.sharedMappings),
-    "shared mappings",
-  );
+  // Mapped paths are checked by core's normalizeFederationOptions, which sees the
+  // pruned/glob-expanded set and skips paths that were never going to be published.
   checkForInvalidImports(Object.keys(normalized.config.shared), "externals");
 
   const activateSsr = nfBuilderOptions.ssr && !nfBuilderOptions.dev;

--- a/src/builders/remote/builder.ts
+++ b/src/builders/remote/builder.ts
@@ -93,7 +93,8 @@ export async function* runRemoteBuilder(
     createFederationCache(cachePath, new SourceFileCache(cachePath))
   );
 
-  checkForInvalidImports(Object.values(normalized.config.sharedMappings), 'shared mappings');
+  // Mapped paths are checked by core's normalizeFederationOptions, which sees the
+  // pruned/glob-expanded set and skips paths that were never going to be published.
   checkForInvalidImports(Object.keys(normalized.config.shared), 'externals');
 
   const start = process.hrtime();

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,5 +6,8 @@ export {
   autoShareScope,
   type PackageShareScopeOptions,
 } from './config/share-utils.js';
+// Nothing Angular-specific to add: the skip list NG_SKIP_LIST seeds applies to npm
+// packages, not to workspace path mappings.
+export { mappingsFromWorkspace } from '@softarc/native-federation/config';
 export { NG_SKIP_LIST } from './config/angular-skip-list.js';
 export { shareAngularLocales } from './config/angular-locales.js';

--- a/src/utils/check-for-invalid-imports.spec.ts
+++ b/src/utils/check-for-invalid-imports.spec.ts
@@ -42,8 +42,8 @@ describe('checkForInvalidImports', () => {
   it('throws for invalid dot imports and logs warnings', () => {
     const imports = ['lodash.merge', '@scope/lib.v2'];
 
-    expect(() => checkForInvalidImports(imports, 'shared mappings')).toThrow(
-      "Invalid 'shared mappings' config. Invalid imports paths detected, consider using a barrel import instead. "
+    expect(() => checkForInvalidImports(imports, 'externals')).toThrow(
+      "Invalid 'externals' config. Invalid imports paths detected, consider using a barrel import instead. "
     );
     expect(warnSpy).toHaveBeenCalledTimes(imports.length);
     expect(warnSpy).toHaveBeenNthCalledWith(


### PR DESCRIPTION
Core's #102 widens sharedMappings to Array<string | [string[], ExternalConfig]> and adds mappingsFromWorkspace() to build that array. Re-export it from '@angular-architects/native-federation/config' so config files can reach it without depending on @softarc/native-federation directly. Plain re-export: what shareAll and fromPackageJson wrap is NG_SKIP_LIST, which selects npm packages, not workspace path mappings. The widened input shape needs no change here, since withNativeFederation takes core's FederationConfig.

Also drops the builders' checkForInvalidImports call for shared mappings. Core now runs the same check as assertBarrelMappings at the end of normalizeFederationOptions, on the set left after pruning and wildcard expansion, so it stays quiet about paths that were never going to be published. Ours ran on that already-validated set and could no longer fire. The externals call stays; core does not check those.